### PR TITLE
[CI] Upgrade Maintainers CI to ubuntu-24.04 (#2670)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,16 @@ jobs:
         ./ci/do_ci.sh cmake.test
 
   cmake_gcc_maintainer_sync_test:
-    name: CMake gcc 13 (maintainer mode, sync)
-    runs-on: ubuntu-latest
+    name: CMake gcc 14 (maintainer mode, sync)
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: setup
       env:
-        CC: /usr/bin/gcc-13
-        CXX: /usr/bin/g++-13
+        CC: /usr/bin/gcc-14
+        CXX: /usr/bin/g++-14
         PROTOBUF_VERSION: 21.12
       run: |
         sudo -E ./ci/setup_googletest.sh
@@ -46,8 +46,8 @@ jobs:
         sudo -E ./ci/install_protobuf.sh
     - name: run cmake gcc (maintainer mode, sync)
       env:
-        CC: /usr/bin/gcc-13
-        CXX: /usr/bin/g++-13
+        CC: /usr/bin/gcc-14
+        CXX: /usr/bin/g++-14
       run: |
         ./ci/do_ci.sh cmake.maintainer.sync.test
     - name: generate test cert
@@ -61,16 +61,16 @@ jobs:
         (cd ./functional/otlp; ./run_test.sh)
 
   cmake_gcc_maintainer_async_test:
-    name: CMake gcc 13 (maintainer mode, async)
-    runs-on: ubuntu-latest
+    name: CMake gcc 14 (maintainer mode, async)
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: setup
       env:
-        CC: /usr/bin/gcc-13
-        CXX: /usr/bin/g++-13
+        CC: /usr/bin/gcc-14
+        CXX: /usr/bin/g++-14
         PROTOBUF_VERSION: 21.12
       run: |
         sudo -E ./ci/setup_googletest.sh
@@ -78,8 +78,8 @@ jobs:
         sudo -E ./ci/install_protobuf.sh
     - name: run cmake gcc (maintainer mode, async)
       env:
-        CC: /usr/bin/gcc-13
-        CXX: /usr/bin/g++-13
+        CC: /usr/bin/gcc-14
+        CXX: /usr/bin/g++-14
       run: |
         ./ci/do_ci.sh cmake.maintainer.async.test
     - name: generate test cert
@@ -93,16 +93,16 @@ jobs:
         (cd ./functional/otlp; ./run_test.sh)
 
   cmake_clang_maintainer_sync_test:
-    name: CMake clang 15 (maintainer mode, sync)
-    runs-on: ubuntu-latest
+    name: CMake clang 18 (maintainer mode, sync)
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: setup
       env:
-        CC: /usr/bin/clang-15
-        CXX: /usr/bin/clang++-15
+        CC: /usr/bin/clang-18
+        CXX: /usr/bin/clang++-18
         PROTOBUF_VERSION: 21.12
       run: |
         sudo -E ./ci/setup_googletest.sh
@@ -110,8 +110,8 @@ jobs:
         sudo -E ./ci/install_protobuf.sh
     - name: run cmake clang (maintainer mode, sync)
       env:
-        CC: /usr/bin/clang-15
-        CXX: /usr/bin/clang++-15
+        CC: /usr/bin/clang-18
+        CXX: /usr/bin/clang++-18
       run: |
         ./ci/do_ci.sh cmake.maintainer.sync.test
     - name: generate test cert
@@ -125,16 +125,16 @@ jobs:
         (cd ./functional/otlp; ./run_test.sh)
 
   cmake_clang_maintainer_async_test:
-    name: CMake clang 15 (maintainer mode, async)
-    runs-on: ubuntu-latest
+    name: CMake clang 18 (maintainer mode, async)
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: setup
       env:
-        CC: /usr/bin/clang-15
-        CXX: /usr/bin/clang++-15
+        CC: /usr/bin/clang-18
+        CXX: /usr/bin/clang++-18
         PROTOBUF_VERSION: 21.12
       run: |
         sudo -E ./ci/setup_googletest.sh
@@ -142,8 +142,8 @@ jobs:
         sudo -E ./ci/install_protobuf.sh
     - name: run cmake clang (maintainer mode, async)
       env:
-        CC: /usr/bin/clang-15
-        CXX: /usr/bin/clang++-15
+        CC: /usr/bin/clang-18
+        CXX: /usr/bin/clang++-18
       run: |
         ./ci/do_ci.sh cmake.maintainer.async.test
     - name: generate test cert
@@ -157,16 +157,16 @@ jobs:
         (cd ./functional/otlp; ./run_test.sh)
 
   cmake_clang_maintainer_abiv2_test:
-    name: CMake clang 15 (maintainer mode, abiv2)
-    runs-on: ubuntu-latest
+    name: CMake clang 18 (maintainer mode, abiv2)
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: setup
       env:
-        CC: /usr/bin/clang-15
-        CXX: /usr/bin/clang++-15
+        CC: /usr/bin/clang-18
+        CXX: /usr/bin/clang++-18
         PROTOBUF_VERSION: 21.12
       run: |
         sudo -E ./ci/setup_googletest.sh
@@ -174,8 +174,8 @@ jobs:
         sudo -E ./ci/install_protobuf.sh
     - name: run cmake clang (maintainer mode, abiv2)
       env:
-        CC: /usr/bin/clang-15
-        CXX: /usr/bin/clang++-15
+        CC: /usr/bin/clang-18
+        CXX: /usr/bin/clang++-18
       run: |
         ./ci/do_ci.sh cmake.maintainer.abiv2.test
     - name: generate test cert

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -65,10 +65,15 @@ mkdir -p "${PLUGIN_DIR}"
 
 IWYU=""
 MAKE_COMMAND="make -k -j \$(nproc)"
-if [[ "${CXX}" == *clang* ]]; then
-  MAKE_COMMAND="make -k CXX=include-what-you-use CXXFLAGS=\"-Xiwyu --error_always\" -j \$(nproc)"
-  IWYU="-DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=iwyu"
-fi
+
+# Temporarily disable the IWYU build.
+# It fails in Ubuntu 24-04 CI with:
+#    Error running 'iwyu': Segmentation fault
+#
+# if [[ "${CXX}" == *clang* ]]; then
+#   MAKE_COMMAND="make -k CXX=include-what-you-use CXXFLAGS=\"-Xiwyu --error_always\" -j \$(nproc)"
+#   IWYU="-DCMAKE_CXX_INCLUDE_WHAT_YOU_USE=iwyu"
+# fi
 
 echo "make command: ${MAKE_COMMAND}"
 echo "IWYU option: ${IWYU}"


### PR DESCRIPTION
* Upgrade Maintainers CI to ubuntu-24.04

* Disable IWYU

Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed