### PR TITLE
CMakeLists.txt: Enable CMAKE_MSVC_RUNTIME_LIBRARY support (#2652)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
   cmake_policy(SET CMP0074 NEW)
 endif()
 
+# Prefer CMAKE_MSVC_RUNTIME_LIBRARY if possible
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
 project(opentelemetry-cpp)
 
 # Mark variables as used so cmake doesn't complain about them


### PR DESCRIPTION
The documentation for CMAKE_MSVC_RUNTIME_LIBRARY states [1]:

> This variable has effect only when policy CMP0091 is set to NEW prior to
> the first project() or enable_language() command that enables a language
> using a compiler targeting the MSVC ABI.

so the current usage of CMAKE_MSVC_RUNTIME_LIBRARY for vcpkg does not work at all.

Let's fix that by setting policy 91 to new if present.

[1]: https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_RUNTIME_LIBRARY.html

Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed