### PR TITLE
 [SDK] Added reserve for spans array in BatchSpanProcessor. (#2724)

### DIFF
--- a/sdk/src/logs/batch_log_record_processor.cc
+++ b/sdk/src/logs/batch_log_record_processor.cc
@@ -208,6 +208,8 @@ void BatchLogRecordProcessor::Export()
       break;
     }
 
+    // Reserve space for the number of records
+    records_arr.reserve(num_records_to_export);
     buffer_.Consume(num_records_to_export,
                     [&](CircularBufferRange<AtomicUniquePtr<Recordable>> range) noexcept {
                       range.ForEach([&](AtomicUniquePtr<Recordable> &ptr) {

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -206,6 +206,10 @@ void BatchSpanProcessor::Export()
       NotifyCompletion(notify_force_flush, exporter_, synchronization_data_);
       break;
     }
+
+    // Reserve space for the number of records
+    spans_arr.reserve(num_records_to_export);
+
     buffer_.Consume(num_records_to_export,
                     [&](CircularBufferRange<AtomicUniquePtr<Recordable>> range) noexcept {
                       range.ForEach([&](AtomicUniquePtr<Recordable> &ptr) {


### PR DESCRIPTION
* Added reserve for spans array in BatchSpanProcessor.

    Added reserve for spans array in BatchSpanProcessor.
    
    Helps to allocate the amount of memory needed for number of records so that dynamic memory allocation doesn't happen in the consume method.
    
    .push_back() reallocates memory each time the method is called.
    
    Using .reserve() would avoid memory reallocation as already the memory is allocated.
    
    References:
    https://cplusplus.com/reference/vector/vector/push_back/
    https://cplusplus.com/reference/vector/vector/reserve/

* Added reserve for spans array in BatchLogProcessor.

Added reserve for spans array in BatchLogProcessor. Same as previously done for BatchSpanProcessor

* Update batch_log_record_processor.cc

* Update batch_span_processor.cc

* Update sdk/src/logs/batch_log_record_processor.cc

Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed