### PR TITLE
[SECURITY] Remove OTLP HTTP support for TLS 1.0 and TLS 1.1, require …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ Increment the:
 
 ## [Unreleased]
 
+* [SECURITY] Remove OTLP HTTP support for TLS 1.0 and TLS 1.1,
+  require TLS 1.2 or better
+  [#2721](https://github.com/open-telemetry/opentelemetry-cpp/pull/2721)
+
+Breaking changes:
+
+* [SECURITY] Remove OTLP HTTP support for TLS 1.0 and TLS 1.1,
+  require TLS 1.2 or better
+  [#2721](https://github.com/open-telemetry/opentelemetry-cpp/pull/2721)
+  * The OTLP HTTP exporter no longer accept options like:
+    * min_TLS = 1.0
+    * min_TLS = 1.1
+    * max_TLS = 1.0
+    * max_TLS = 1.1
+  * When connecting to an OTLP HTTP endpoint, using `https`,
+    the connection will require TLS 1.2 by default,
+    unless min_TLS is set to 1.3
+  * Plain `http` connections (insecure) are not affected.
+
 ## [1.16.0] 2024-06-21
 
 * [BUILD] Upgrade bazel abseil from 20220623.1 to 20230802.2

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_environment.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_environment.h
@@ -111,7 +111,7 @@ std::string GetOtlpDefaultTracesSslTlsMaxVersion();
 std::string GetOtlpDefaultMetricsSslTlsMaxVersion();
 std::string GetOtlpDefaultLogsSslTlsMaxVersion();
 
-// For TLS 1.0, 1.1, 1.2
+// For TLS 1.2
 std::string GetOtlpDefaultTracesSslTlsCipher();
 std::string GetOtlpDefaultMetricsSslTlsCipher();
 std::string GetOtlpDefaultLogsSslTlsCipher();

--- a/ext/include/opentelemetry/ext/http/client/http_client.h
+++ b/ext/include/opentelemetry/ext/http/client/http_client.h
@@ -192,9 +192,7 @@ struct HttpSslOptions
   /**
     Minimum SSL version to use.
     Valid values are:
-    - empty (no minimum version required)
-    - "1.0" (TLSv1.0)
-    - "1.1" (TLSv1.1)
+    - empty (defaults to TLSv1.2)
     - "1.2" (TLSv1.2)
     - "1.3" (TLSv1.3)
   */
@@ -204,8 +202,6 @@ struct HttpSslOptions
     Maximum SSL version to use.
     Valid values are:
     - empty (no maximum version required)
-    - "1.0" (TLSv1.0)
-    - "1.1" (TLSv1.1)
     - "1.2" (TLSv1.2)
     - "1.3" (TLSv1.3)
   */
@@ -213,7 +209,7 @@ struct HttpSslOptions
 
   /**
     TLS Cipher.
-    This is for TLS 1.0, 1.1 and 1.2.
+    This is for TLS 1.2.
     The list is delimited by colons (":").
     Cipher names depends on the underlying CURL implementation.
   */

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -414,16 +414,16 @@ void HttpOperation::Cleanup()
   To represent versions, the following symbols are needed:
 
   Added in CURL 7.34.0:
-  - CURL_SSLVERSION_TLSv1_0
-  - CURL_SSLVERSION_TLSv1_1
+  - CURL_SSLVERSION_TLSv1_0 (do not use)
+  - CURL_SSLVERSION_TLSv1_1 (do not use)
   - CURL_SSLVERSION_TLSv1_2
 
   Added in CURL 7.52.0:
   - CURL_SSLVERSION_TLSv1_3
 
   Added in CURL 7.54.0:
-  - CURL_SSLVERSION_MAX_TLSv1_0
-  - CURL_SSLVERSION_MAX_TLSv1_1
+  - CURL_SSLVERSION_MAX_TLSv1_0 (do not use)
+  - CURL_SSLVERSION_MAX_TLSv1_1 (do not use)
   - CURL_SSLVERSION_MAX_TLSv1_2
   - CURL_SSLVERSION_MAX_TLSv1_3
 
@@ -439,16 +439,6 @@ void HttpOperation::Cleanup()
 static long parse_min_ssl_version(std::string version)
 {
 #ifdef HAVE_TLS_VERSION
-  if (version == "1.0")
-  {
-    return CURL_SSLVERSION_TLSv1_0;
-  }
-
-  if (version == "1.1")
-  {
-    return CURL_SSLVERSION_TLSv1_1;
-  }
-
   if (version == "1.2")
   {
     return CURL_SSLVERSION_TLSv1_2;
@@ -466,16 +456,6 @@ static long parse_min_ssl_version(std::string version)
 static long parse_max_ssl_version(std::string version)
 {
 #ifdef HAVE_TLS_VERSION
-  if (version == "1.0")
-  {
-    return CURL_SSLVERSION_MAX_TLSv1_0;
-  }
-
-  if (version == "1.1")
-  {
-    return CURL_SSLVERSION_MAX_TLSv1_1;
-  }
-
   if (version == "1.2")
   {
     return CURL_SSLVERSION_MAX_TLSv1_2;
@@ -730,7 +710,12 @@ CURLcode HttpOperation::Setup()
 
     /* 4 - TLS */
 
+#ifdef HAVE_TLS_VERSION
+    /* By default, TLSv1.2 or better is required (if we have TLS). */
+    long min_ssl_version = CURL_SSLVERSION_TLSv1_2;
+#else
     long min_ssl_version = 0;
+#endif
 
     if (!ssl_options_.ssl_min_tls.empty())
     {
@@ -748,6 +733,11 @@ CURLcode HttpOperation::Setup()
 #endif
     }
 
+    /*
+     * Do not set a max TLS version by default.
+     * The CURL + openssl library may be more recent than this code,
+     * and support a version we do not know about.
+     */
     long max_ssl_version = 0;
 
     if (!ssl_options_.ssl_max_tls.empty())
@@ -780,7 +770,7 @@ CURLcode HttpOperation::Setup()
 
     if (!ssl_options_.ssl_cipher.empty())
     {
-      /* TLS 1.0, 1.1, 1.2 */
+      /* TLS 1.2 */
       const char *cipher_list = ssl_options_.ssl_cipher.c_str();
 
       rc = SetCurlStrOption(CURLOPT_SSL_CIPHER_LIST, cipher_list);

--- a/functional/otlp/func_http_main.cc
+++ b/functional/otlp/func_http_main.cc
@@ -54,6 +54,8 @@ struct TestResult
   bool found_request_send_failure = false;
   bool found_export_error         = false;
   bool found_export_success       = false;
+  bool found_unknown_min_tls      = false;
+  bool found_unknown_max_tls      = false;
 
   void reset()
   {
@@ -62,6 +64,8 @@ struct TestResult
     found_request_send_failure = false;
     found_export_error         = false;
     found_export_success       = false;
+    found_unknown_min_tls      = false;
+    found_unknown_max_tls      = false;
   }
 };
 
@@ -95,6 +99,20 @@ void parse_error_msg(TestResult *result, std::string msg)
   if (msg.find(export_failed) != std::string::npos)
   {
     result->found_export_error = true;
+  }
+
+  static std::string unknown_min_tls("Unknown min TLS version");
+
+  if (msg.find(unknown_min_tls) != std::string::npos)
+  {
+    result->found_unknown_min_tls = true;
+  }
+
+  static std::string unknown_max_tls("Unknown max TLS version");
+
+  if (msg.find(unknown_max_tls) != std::string::npos)
+  {
+    result->found_unknown_max_tls = true;
   }
 }
 
@@ -501,6 +519,24 @@ int expect_success()
 int expect_request_send_failed()
 {
   if (g_test_result.found_export_error && g_test_result.found_request_send_failure)
+  {
+    return TEST_PASSED;
+  }
+  return TEST_FAILED;
+}
+
+int expect_unknown_min_tls()
+{
+  if (g_test_result.found_export_error && g_test_result.found_unknown_min_tls)
+  {
+    return TEST_PASSED;
+  }
+  return TEST_FAILED;
+}
+
+int expect_unknown_max_tls()
+{
+  if (g_test_result.found_export_error && g_test_result.found_unknown_max_tls)
   {
     return TEST_PASSED;
   }
@@ -928,7 +964,7 @@ int test_min_tls_unknown()
     return expect_export_failed();
   }
 
-  return expect_connection_failed();
+  return expect_unknown_min_tls();
 }
 
 int test_min_tls_10()
@@ -963,7 +999,7 @@ int test_min_tls_10()
     return expect_connection_failed();
   }
 
-  return expect_success();
+  return expect_unknown_min_tls();
 }
 
 int test_min_tls_11()
@@ -998,7 +1034,7 @@ int test_min_tls_11()
     return expect_connection_failed();
   }
 
-  return expect_success();
+  return expect_unknown_min_tls();
 }
 
 int test_min_tls_12()
@@ -1098,7 +1134,7 @@ int test_max_tls_unknown()
     return expect_export_failed();
   }
 
-  return expect_connection_failed();
+  return expect_unknown_max_tls();
 }
 
 int test_max_tls_10()
@@ -1134,7 +1170,7 @@ int test_max_tls_10()
   }
 
   // No support for TLS 1.0
-  return expect_connection_failed();
+  return expect_unknown_max_tls();
 }
 
 int test_max_tls_11()
@@ -1170,7 +1206,7 @@ int test_max_tls_11()
   }
 
   // No support for TLS 1.1
-  return expect_connection_failed();
+  return expect_unknown_max_tls();
 }
 
 int test_max_tls_12()
@@ -1277,7 +1313,7 @@ int test_range_tls_10()
   }
 
   // No support for TLS 1.0
-  return expect_connection_failed();
+  return expect_unknown_min_tls();
 }
 
 int test_range_tls_11()
@@ -1314,7 +1350,7 @@ int test_range_tls_11()
   }
 
   // No support for TLS 1.0
-  return expect_connection_failed();
+  return expect_unknown_min_tls();
 }
 
 int test_range_tls_12()
@@ -1423,7 +1459,7 @@ int test_range_tls_10_11()
   }
 
   // No support for TLS 1.0, TLS 1.1
-  return expect_connection_failed();
+  return expect_unknown_min_tls();
 }
 
 int test_range_tls_10_12()
@@ -1459,7 +1495,7 @@ int test_range_tls_10_12()
     return expect_connection_failed();
   }
 
-  return expect_success();
+  return expect_unknown_min_tls();
 }
 
 int test_range_tls_10_13()
@@ -1495,7 +1531,7 @@ int test_range_tls_10_13()
     return expect_connection_failed();
   }
 
-  return expect_success();
+  return expect_unknown_min_tls();
 }
 
 int test_range_tls_11_10()
@@ -1563,7 +1599,7 @@ int test_range_tls_11_12()
     return expect_connection_failed();
   }
 
-  return expect_success();
+  return expect_unknown_min_tls();
 }
 
 int test_range_tls_11_13()
@@ -1599,7 +1635,7 @@ int test_range_tls_11_13()
     return expect_connection_failed();
   }
 
-  return expect_success();
+  return expect_unknown_min_tls();
 }
 
 int test_range_tls_12_10()


### PR DESCRIPTION
…TLS 1.2 (#2722)

Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed