### PR TITLE
[CI] Update otel-collector version (#3067)

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -20,7 +20,7 @@ function install_prometheus_cpp_client
 function run_benchmarks
 {
   docker run -d --rm -it -p 4317:4317 -p 4318:4318 -v \
-    $(pwd)/examples/otlp:/cfg otel/opentelemetry-collector:0.38.0 \
+    $(pwd)/examples/otlp:/cfg otel/opentelemetry-collector:0.109.0 \
     --config=/cfg/opentelemetry-collector-config/config.dev.yaml
 
   [ -z "${BENCHMARK_DIR}" ] && export BENCHMARK_DIR=$HOME/benchmark

--- a/examples/otlp/README.md
+++ b/examples/otlp/README.md
@@ -50,13 +50,13 @@ OpenTelemetry Collector with an OTLP receiver by running:
 - On Unix based systems use:
 
 ```console
-docker run --rm -it -p 4317:4317 -p 4318:4318 -v $(pwd)/examples/otlp:/cfg otel/opentelemetry-collector:0.59.0 --config=/cfg/opentelemetry-collector-config/config.dev.yaml
+docker run --rm -it -p 4317:4317 -p 4318:4318 -v $(pwd)/examples/otlp:/cfg otel/opentelemetry-collector:0.109.0 --config=/cfg/opentelemetry-collector-config/config.dev.yaml
 ```
 
 - On Windows use:
 
 ```console
-docker run --rm -it -p 4317:4317 -p 4318:4318 -v "%cd%/examples/otlp":/cfg otel/opentelemetry-collector:0.59.0 --config=/cfg/opentelemetry-collector-config/config.dev.yaml
+docker run --rm -it -p 4317:4317 -p 4318:4318 -v "%cd%/examples/otlp":/cfg otel/opentelemetry-collector:0.109.0 --config=/cfg/opentelemetry-collector-config/config.dev.yaml
 ```
 
 Note that the OTLP gRPC and HTTP exporters connects to the Collector at `localhost:4317` and `localhost:4318/v1/traces` respectively. This can be changed with first argument from command-line, for example:


### PR DESCRIPTION
Looks like otel-collector equal or higher than 0.86.0 has the "debug" exporter.

So updated the README.md with the latest version of the otel-collector (v0.109.0) and also the CI script.

Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed