### PR TITLE
[SEMCONV] Metrics are incorrectly prefixed with `metric.` (#3228)

### DIFF
--- a/api/include/opentelemetry/semconv/http_metrics.h
+++ b/api/include/opentelemetry/semconv/http_metrics.h
@@ -25,8 +25,7 @@ namespace http
  * <p>
  * histogram
  */
-static constexpr const char *kMetricHttpClientRequestDuration =
-    "metric.http.client.request.duration";
+static constexpr const char *kMetricHttpClientRequestDuration = "http.client.request.duration";
 static constexpr const char *descrMetricHttpClientRequestDuration =
     "Duration of HTTP client requests.";
 static constexpr const char *unitMetricHttpClientRequestDuration = "s";
@@ -52,8 +51,7 @@ CreateSyncDoubleMetricHttpClientRequestDuration(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricHttpServerRequestDuration =
-    "metric.http.server.request.duration";
+static constexpr const char *kMetricHttpServerRequestDuration = "http.server.request.duration";
 static constexpr const char *descrMetricHttpServerRequestDuration =
     "Duration of HTTP server requests.";
 static constexpr const char *unitMetricHttpServerRequestDuration = "s";

--- a/api/include/opentelemetry/semconv/incubating/container_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/container_metrics.h
@@ -27,7 +27,7 @@ namespace container
  * <p>
  * counter
  */
-static constexpr const char *kMetricContainerCpuTime     = "metric.container.cpu.time";
+static constexpr const char *kMetricContainerCpuTime     = "container.cpu.time";
 static constexpr const char *descrMetricContainerCpuTime = "Total CPU time consumed";
 static constexpr const char *unitMetricContainerCpuTime  = "s";
 
@@ -66,7 +66,7 @@ CreateAsyncDoubleMetricContainerCpuTime(metrics::Meter *meter)
  * <p>
  * gauge
  */
-static constexpr const char *kMetricContainerCpuUsage = "metric.container.cpu.usage";
+static constexpr const char *kMetricContainerCpuUsage = "container.cpu.usage";
 static constexpr const char *descrMetricContainerCpuUsage =
     "Container's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs";
 static constexpr const char *unitMetricContainerCpuUsage = "{cpu}";
@@ -109,7 +109,7 @@ CreateAsyncDoubleMetricContainerCpuUsage(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricContainerDiskIo     = "metric.container.disk.io";
+static constexpr const char *kMetricContainerDiskIo     = "container.disk.io";
 static constexpr const char *descrMetricContainerDiskIo = "Disk bytes for the container.";
 static constexpr const char *unitMetricContainerDiskIo  = "By";
 
@@ -148,7 +148,7 @@ CreateAsyncDoubleMetricContainerDiskIo(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricContainerMemoryUsage     = "metric.container.memory.usage";
+static constexpr const char *kMetricContainerMemoryUsage     = "container.memory.usage";
 static constexpr const char *descrMetricContainerMemoryUsage = "Memory usage of the container.";
 static constexpr const char *unitMetricContainerMemoryUsage  = "By";
 
@@ -187,7 +187,7 @@ CreateAsyncDoubleMetricContainerMemoryUsage(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricContainerNetworkIo     = "metric.container.network.io";
+static constexpr const char *kMetricContainerNetworkIo     = "container.network.io";
 static constexpr const char *descrMetricContainerNetworkIo = "Network bytes for the container.";
 static constexpr const char *unitMetricContainerNetworkIo  = "By";
 
@@ -226,7 +226,7 @@ CreateAsyncDoubleMetricContainerNetworkIo(metrics::Meter *meter)
  * as a floating point number with the highest precision available. The actual accuracy would depend
  * on the instrumentation and operating system. <p> gauge
  */
-static constexpr const char *kMetricContainerUptime     = "metric.container.uptime";
+static constexpr const char *kMetricContainerUptime     = "container.uptime";
 static constexpr const char *descrMetricContainerUptime = "The time the container has been running";
 static constexpr const char *unitMetricContainerUptime  = "s";
 

--- a/api/include/opentelemetry/semconv/incubating/db_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/db_metrics.h
@@ -24,7 +24,7 @@ namespace db
  * The number of connections that are currently in state described by the @code state @endcode
  * attribute <p> updowncounter
  */
-static constexpr const char *kMetricDbClientConnectionCount = "metric.db.client.connection.count";
+static constexpr const char *kMetricDbClientConnectionCount = "db.client.connection.count";
 static constexpr const char *descrMetricDbClientConnectionCount =
     "The number of connections that are currently in state described by the `state` attribute";
 static constexpr const char *unitMetricDbClientConnectionCount = "{connection}";
@@ -67,7 +67,7 @@ CreateAsyncDoubleMetricDbClientConnectionCount(metrics::Meter *meter)
  * histogram
  */
 static constexpr const char *kMetricDbClientConnectionCreateTime =
-    "metric.db.client.connection.create_time";
+    "db.client.connection.create_time";
 static constexpr const char *descrMetricDbClientConnectionCreateTime =
     "The time it took to create a new connection";
 static constexpr const char *unitMetricDbClientConnectionCreateTime = "s";
@@ -93,8 +93,7 @@ CreateSyncDoubleMetricDbClientConnectionCreateTime(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricDbClientConnectionIdleMax =
-    "metric.db.client.connection.idle.max";
+static constexpr const char *kMetricDbClientConnectionIdleMax = "db.client.connection.idle.max";
 static constexpr const char *descrMetricDbClientConnectionIdleMax =
     "The maximum number of idle open connections allowed";
 static constexpr const char *unitMetricDbClientConnectionIdleMax = "{connection}";
@@ -136,8 +135,7 @@ CreateAsyncDoubleMetricDbClientConnectionIdleMax(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricDbClientConnectionIdleMin =
-    "metric.db.client.connection.idle.min";
+static constexpr const char *kMetricDbClientConnectionIdleMin = "db.client.connection.idle.min";
 static constexpr const char *descrMetricDbClientConnectionIdleMin =
     "The minimum number of idle open connections allowed";
 static constexpr const char *unitMetricDbClientConnectionIdleMin = "{connection}";
@@ -179,7 +177,7 @@ CreateAsyncDoubleMetricDbClientConnectionIdleMin(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricDbClientConnectionMax = "metric.db.client.connection.max";
+static constexpr const char *kMetricDbClientConnectionMax = "db.client.connection.max";
 static constexpr const char *descrMetricDbClientConnectionMax =
     "The maximum number of open connections allowed";
 static constexpr const char *unitMetricDbClientConnectionMax = "{connection}";
@@ -222,7 +220,7 @@ CreateAsyncDoubleMetricDbClientConnectionMax(metrics::Meter *meter)
  * updowncounter
  */
 static constexpr const char *kMetricDbClientConnectionPendingRequests =
-    "metric.db.client.connection.pending_requests";
+    "db.client.connection.pending_requests";
 static constexpr const char *descrMetricDbClientConnectionPendingRequests =
     "The number of current pending requests for an open connection";
 static constexpr const char *unitMetricDbClientConnectionPendingRequests = "{request}";
@@ -264,8 +262,7 @@ CreateAsyncDoubleMetricDbClientConnectionPendingRequests(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricDbClientConnectionTimeouts =
-    "metric.db.client.connection.timeouts";
+static constexpr const char *kMetricDbClientConnectionTimeouts = "db.client.connection.timeouts";
 static constexpr const char *descrMetricDbClientConnectionTimeouts =
     "The number of connection timeouts that have occurred trying to obtain a connection from the "
     "pool";
@@ -308,8 +305,7 @@ CreateAsyncDoubleMetricDbClientConnectionTimeouts(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricDbClientConnectionUseTime =
-    "metric.db.client.connection.use_time";
+static constexpr const char *kMetricDbClientConnectionUseTime = "db.client.connection.use_time";
 static constexpr const char *descrMetricDbClientConnectionUseTime =
     "The time between borrowing a connection and returning it to the pool";
 static constexpr const char *unitMetricDbClientConnectionUseTime = "s";
@@ -335,8 +331,7 @@ CreateSyncDoubleMetricDbClientConnectionUseTime(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricDbClientConnectionWaitTime =
-    "metric.db.client.connection.wait_time";
+static constexpr const char *kMetricDbClientConnectionWaitTime = "db.client.connection.wait_time";
 static constexpr const char *descrMetricDbClientConnectionWaitTime =
     "The time it took to obtain an open connection from the pool";
 static constexpr const char *unitMetricDbClientConnectionWaitTime = "s";
@@ -366,7 +361,7 @@ CreateSyncDoubleMetricDbClientConnectionWaitTime(metrics::Meter *meter)
  */
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *kMetricDbClientConnectionsCreateTime =
-    "metric.db.client.connections.create_time";
+    "db.client.connections.create_time";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricDbClientConnectionsCreateTime =
     "Deprecated, use `db.client.connection.create_time` instead. Note: the unit also changed from "
@@ -401,8 +396,7 @@ CreateSyncDoubleMetricDbClientConnectionsCreateTime(metrics::Meter *meter)
  * updowncounter
  */
 OPENTELEMETRY_DEPRECATED
-static constexpr const char *kMetricDbClientConnectionsIdleMax =
-    "metric.db.client.connections.idle.max";
+static constexpr const char *kMetricDbClientConnectionsIdleMax = "db.client.connections.idle.max";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricDbClientConnectionsIdleMax =
     "Deprecated, use `db.client.connection.idle.max` instead.";
@@ -454,8 +448,7 @@ CreateAsyncDoubleMetricDbClientConnectionsIdleMax(metrics::Meter *meter)
  * updowncounter
  */
 OPENTELEMETRY_DEPRECATED
-static constexpr const char *kMetricDbClientConnectionsIdleMin =
-    "metric.db.client.connections.idle.min";
+static constexpr const char *kMetricDbClientConnectionsIdleMin = "db.client.connections.idle.min";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricDbClientConnectionsIdleMin =
     "Deprecated, use `db.client.connection.idle.min` instead.";
@@ -507,7 +500,7 @@ CreateAsyncDoubleMetricDbClientConnectionsIdleMin(metrics::Meter *meter)
  * updowncounter
  */
 OPENTELEMETRY_DEPRECATED
-static constexpr const char *kMetricDbClientConnectionsMax = "metric.db.client.connections.max";
+static constexpr const char *kMetricDbClientConnectionsMax = "db.client.connections.max";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricDbClientConnectionsMax =
     "Deprecated, use `db.client.connection.max` instead.";
@@ -560,7 +553,7 @@ CreateAsyncDoubleMetricDbClientConnectionsMax(metrics::Meter *meter)
  */
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *kMetricDbClientConnectionsPendingRequests =
-    "metric.db.client.connections.pending_requests";
+    "db.client.connections.pending_requests";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricDbClientConnectionsPendingRequests =
     "Deprecated, use `db.client.connection.pending_requests` instead.";
@@ -612,8 +605,7 @@ CreateAsyncDoubleMetricDbClientConnectionsPendingRequests(metrics::Meter *meter)
  * counter
  */
 OPENTELEMETRY_DEPRECATED
-static constexpr const char *kMetricDbClientConnectionsTimeouts =
-    "metric.db.client.connections.timeouts";
+static constexpr const char *kMetricDbClientConnectionsTimeouts = "db.client.connections.timeouts";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricDbClientConnectionsTimeouts =
     "Deprecated, use `db.client.connection.timeouts` instead.";
@@ -665,7 +657,7 @@ CreateAsyncDoubleMetricDbClientConnectionsTimeouts(metrics::Meter *meter)
  * updowncounter
  */
 OPENTELEMETRY_DEPRECATED
-static constexpr const char *kMetricDbClientConnectionsUsage = "metric.db.client.connections.usage";
+static constexpr const char *kMetricDbClientConnectionsUsage = "db.client.connections.usage";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricDbClientConnectionsUsage =
     "Deprecated, use `db.client.connection.count` instead.";
@@ -716,8 +708,7 @@ CreateAsyncDoubleMetricDbClientConnectionsUsage(metrics::Meter *meter)
  * ms @endcode to @code s @endcode. <p> histogram
  */
 OPENTELEMETRY_DEPRECATED
-static constexpr const char *kMetricDbClientConnectionsUseTime =
-    "metric.db.client.connections.use_time";
+static constexpr const char *kMetricDbClientConnectionsUseTime = "db.client.connections.use_time";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricDbClientConnectionsUseTime =
     "Deprecated, use `db.client.connection.use_time` instead. Note: the unit also changed from "
@@ -751,8 +742,7 @@ CreateSyncDoubleMetricDbClientConnectionsUseTime(metrics::Meter *meter)
  * ms @endcode to @code s @endcode. <p> histogram
  */
 OPENTELEMETRY_DEPRECATED
-static constexpr const char *kMetricDbClientConnectionsWaitTime =
-    "metric.db.client.connections.wait_time";
+static constexpr const char *kMetricDbClientConnectionsWaitTime = "db.client.connections.wait_time";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricDbClientConnectionsWaitTime =
     "Deprecated, use `db.client.connection.wait_time` instead. Note: the unit also changed from "
@@ -784,7 +774,7 @@ CreateSyncDoubleMetricDbClientConnectionsWaitTime(metrics::Meter *meter)
  * updowncounter
  */
 static constexpr const char *kMetricDbClientCosmosdbActiveInstanceCount =
-    "metric.db.client.cosmosdb.active_instance.count";
+    "db.client.cosmosdb.active_instance.count";
 static constexpr const char *descrMetricDbClientCosmosdbActiveInstanceCount =
     "Number of active client instances";
 static constexpr const char *unitMetricDbClientCosmosdbActiveInstanceCount = "{instance}";
@@ -826,7 +816,7 @@ CreateAsyncDoubleMetricDbClientCosmosdbActiveInstanceCount(metrics::Meter *meter
  * by the operation <p> histogram
  */
 static constexpr const char *kMetricDbClientCosmosdbOperationRequestCharge =
-    "metric.db.client.cosmosdb.operation.request_charge";
+    "db.client.cosmosdb.operation.request_charge";
 static constexpr const char *descrMetricDbClientCosmosdbOperationRequestCharge =
     "[Request charge](https://learn.microsoft.com/azure/cosmos-db/request-units) consumed by the "
     "operation";
@@ -855,8 +845,7 @@ CreateSyncDoubleMetricDbClientCosmosdbOperationRequestCharge(metrics::Meter *met
  * <p>
  * histogram
  */
-static constexpr const char *kMetricDbClientOperationDuration =
-    "metric.db.client.operation.duration";
+static constexpr const char *kMetricDbClientOperationDuration = "db.client.operation.duration";
 static constexpr const char *descrMetricDbClientOperationDuration =
     "Duration of database client operations.";
 static constexpr const char *unitMetricDbClientOperationDuration = "s";
@@ -883,7 +872,7 @@ CreateSyncDoubleMetricDbClientOperationDuration(metrics::Meter *meter)
  * histogram
  */
 static constexpr const char *kMetricDbClientResponseReturnedRows =
-    "metric.db.client.response.returned_rows";
+    "db.client.response.returned_rows";
 static constexpr const char *descrMetricDbClientResponseReturnedRows =
     "The actual number of records returned by the database operation.";
 static constexpr const char *unitMetricDbClientResponseReturnedRows = "{row}";

--- a/api/include/opentelemetry/semconv/incubating/dns_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/dns_metrics.h
@@ -25,7 +25,7 @@ namespace dns
  * <p>
  * histogram
  */
-static constexpr const char *kMetricDnsLookupDuration = "metric.dns.lookup.duration";
+static constexpr const char *kMetricDnsLookupDuration = "dns.lookup.duration";
 static constexpr const char *descrMetricDnsLookupDuration =
     "Measures the time taken to perform a DNS lookup.";
 static constexpr const char *unitMetricDnsLookupDuration = "s";

--- a/api/include/opentelemetry/semconv/incubating/faas_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/faas_metrics.h
@@ -25,7 +25,7 @@ namespace faas
  * <p>
  * counter
  */
-static constexpr const char *kMetricFaasColdstarts     = "metric.faas.coldstarts";
+static constexpr const char *kMetricFaasColdstarts     = "faas.coldstarts";
 static constexpr const char *descrMetricFaasColdstarts = "Number of invocation cold starts";
 static constexpr const char *unitMetricFaasColdstarts  = "{coldstart}";
 
@@ -62,7 +62,7 @@ CreateAsyncDoubleMetricFaasColdstarts(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricFaasCpuUsage     = "metric.faas.cpu_usage";
+static constexpr const char *kMetricFaasCpuUsage     = "faas.cpu_usage";
 static constexpr const char *descrMetricFaasCpuUsage = "Distribution of CPU usage per invocation";
 static constexpr const char *unitMetricFaasCpuUsage  = "s";
 
@@ -85,7 +85,7 @@ static inline nostd::unique_ptr<metrics::Histogram<double>> CreateSyncDoubleMetr
  * <p>
  * counter
  */
-static constexpr const char *kMetricFaasErrors     = "metric.faas.errors";
+static constexpr const char *kMetricFaasErrors     = "faas.errors";
 static constexpr const char *descrMetricFaasErrors = "Number of invocation errors";
 static constexpr const char *unitMetricFaasErrors  = "{error}";
 
@@ -120,7 +120,7 @@ static inline nostd::shared_ptr<metrics::ObservableInstrument> CreateAsyncDouble
  * <p>
  * histogram
  */
-static constexpr const char *kMetricFaasInitDuration = "metric.faas.init_duration";
+static constexpr const char *kMetricFaasInitDuration = "faas.init_duration";
 static constexpr const char *descrMetricFaasInitDuration =
     "Measures the duration of the function's initialization, such as a cold start";
 static constexpr const char *unitMetricFaasInitDuration = "s";
@@ -144,7 +144,7 @@ static inline nostd::unique_ptr<metrics::Histogram<double>> CreateSyncDoubleMetr
  * <p>
  * counter
  */
-static constexpr const char *kMetricFaasInvocations     = "metric.faas.invocations";
+static constexpr const char *kMetricFaasInvocations     = "faas.invocations";
 static constexpr const char *descrMetricFaasInvocations = "Number of successful invocations";
 static constexpr const char *unitMetricFaasInvocations  = "{invocation}";
 
@@ -181,7 +181,7 @@ CreateAsyncDoubleMetricFaasInvocations(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricFaasInvokeDuration = "metric.faas.invoke_duration";
+static constexpr const char *kMetricFaasInvokeDuration = "faas.invoke_duration";
 static constexpr const char *descrMetricFaasInvokeDuration =
     "Measures the duration of the function's logic execution";
 static constexpr const char *unitMetricFaasInvokeDuration = "s";
@@ -205,7 +205,7 @@ CreateSyncDoubleMetricFaasInvokeDuration(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricFaasMemUsage = "metric.faas.mem_usage";
+static constexpr const char *kMetricFaasMemUsage = "faas.mem_usage";
 static constexpr const char *descrMetricFaasMemUsage =
     "Distribution of max memory usage per invocation";
 static constexpr const char *unitMetricFaasMemUsage = "By";
@@ -229,7 +229,7 @@ static inline nostd::unique_ptr<metrics::Histogram<double>> CreateSyncDoubleMetr
  * <p>
  * histogram
  */
-static constexpr const char *kMetricFaasNetIo     = "metric.faas.net_io";
+static constexpr const char *kMetricFaasNetIo     = "faas.net_io";
 static constexpr const char *descrMetricFaasNetIo = "Distribution of net I/O usage per invocation";
 static constexpr const char *unitMetricFaasNetIo  = "By";
 
@@ -250,7 +250,7 @@ static inline nostd::unique_ptr<metrics::Histogram<double>> CreateSyncDoubleMetr
  * <p>
  * counter
  */
-static constexpr const char *kMetricFaasTimeouts     = "metric.faas.timeouts";
+static constexpr const char *kMetricFaasTimeouts     = "faas.timeouts";
 static constexpr const char *descrMetricFaasTimeouts = "Number of invocation timeouts";
 static constexpr const char *unitMetricFaasTimeouts  = "{timeout}";
 

--- a/api/include/opentelemetry/semconv/incubating/gen_ai_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/gen_ai_metrics.h
@@ -26,7 +26,7 @@ namespace gen_ai
  * histogram
  */
 static constexpr const char *kMetricGenAiClientOperationDuration =
-    "metric.gen_ai.client.operation.duration";
+    "gen_ai.client.operation.duration";
 static constexpr const char *descrMetricGenAiClientOperationDuration = "GenAI operation duration";
 static constexpr const char *unitMetricGenAiClientOperationDuration  = "s";
 
@@ -51,7 +51,7 @@ CreateSyncDoubleMetricGenAiClientOperationDuration(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricGenAiClientTokenUsage = "metric.gen_ai.client.token.usage";
+static constexpr const char *kMetricGenAiClientTokenUsage = "gen_ai.client.token.usage";
 static constexpr const char *descrMetricGenAiClientTokenUsage =
     "Measures number of input and output tokens used";
 static constexpr const char *unitMetricGenAiClientTokenUsage = "{token}";
@@ -77,8 +77,7 @@ CreateSyncDoubleMetricGenAiClientTokenUsage(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricGenAiServerRequestDuration =
-    "metric.gen_ai.server.request.duration";
+static constexpr const char *kMetricGenAiServerRequestDuration = "gen_ai.server.request.duration";
 static constexpr const char *descrMetricGenAiServerRequestDuration =
     "Generative AI server request duration such as time-to-last byte or last output token";
 static constexpr const char *unitMetricGenAiServerRequestDuration = "s";
@@ -105,7 +104,7 @@ CreateSyncDoubleMetricGenAiServerRequestDuration(metrics::Meter *meter)
  * histogram
  */
 static constexpr const char *kMetricGenAiServerTimePerOutputToken =
-    "metric.gen_ai.server.time_per_output_token";
+    "gen_ai.server.time_per_output_token";
 static constexpr const char *descrMetricGenAiServerTimePerOutputToken =
     "Time per output token generated after the first token for successful responses";
 static constexpr const char *unitMetricGenAiServerTimePerOutputToken = "s";
@@ -132,7 +131,7 @@ CreateSyncDoubleMetricGenAiServerTimePerOutputToken(metrics::Meter *meter)
  * histogram
  */
 static constexpr const char *kMetricGenAiServerTimeToFirstToken =
-    "metric.gen_ai.server.time_to_first_token";
+    "gen_ai.server.time_to_first_token";
 static constexpr const char *descrMetricGenAiServerTimeToFirstToken =
     "Time to generate first token for successful responses";
 static constexpr const char *unitMetricGenAiServerTimeToFirstToken = "s";

--- a/api/include/opentelemetry/semconv/incubating/http_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/http_metrics.h
@@ -25,7 +25,7 @@ namespace http
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricHttpClientActiveRequests = "metric.http.client.active_requests";
+static constexpr const char *kMetricHttpClientActiveRequests = "http.client.active_requests";
 static constexpr const char *descrMetricHttpClientActiveRequests =
     "Number of active HTTP requests.";
 static constexpr const char *unitMetricHttpClientActiveRequests = "{request}";
@@ -68,7 +68,7 @@ CreateAsyncDoubleMetricHttpClientActiveRequests(metrics::Meter *meter)
  * histogram
  */
 static constexpr const char *kMetricHttpClientConnectionDuration =
-    "metric.http.client.connection.duration";
+    "http.client.connection.duration";
 static constexpr const char *descrMetricHttpClientConnectionDuration =
     "The duration of the successfully established outbound HTTP connections.";
 static constexpr const char *unitMetricHttpClientConnectionDuration = "s";
@@ -94,8 +94,7 @@ CreateSyncDoubleMetricHttpClientConnectionDuration(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricHttpClientOpenConnections =
-    "metric.http.client.open_connections";
+static constexpr const char *kMetricHttpClientOpenConnections = "http.client.open_connections";
 static constexpr const char *descrMetricHttpClientOpenConnections =
     "Number of outbound HTTP connections that are currently active or idle on the client.";
 static constexpr const char *unitMetricHttpClientOpenConnections = "{connection}";
@@ -140,8 +139,7 @@ CreateAsyncDoubleMetricHttpClientOpenConnections(metrics::Meter *meter)
  * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
  * header. For requests using transport encoding, this should be the compressed size. <p> histogram
  */
-static constexpr const char *kMetricHttpClientRequestBodySize =
-    "metric.http.client.request.body.size";
+static constexpr const char *kMetricHttpClientRequestBodySize = "http.client.request.body.size";
 static constexpr const char *descrMetricHttpClientRequestBodySize =
     "Size of HTTP client request bodies.";
 static constexpr const char *unitMetricHttpClientRequestBodySize = "By";
@@ -167,8 +165,7 @@ CreateSyncDoubleMetricHttpClientRequestBodySize(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricHttpClientRequestDuration =
-    "metric.http.client.request.duration";
+static constexpr const char *kMetricHttpClientRequestDuration = "http.client.request.duration";
 static constexpr const char *descrMetricHttpClientRequestDuration =
     "Duration of HTTP client requests.";
 static constexpr const char *unitMetricHttpClientRequestDuration = "s";
@@ -197,8 +194,7 @@ CreateSyncDoubleMetricHttpClientRequestDuration(metrics::Meter *meter)
  * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
  * header. For requests using transport encoding, this should be the compressed size. <p> histogram
  */
-static constexpr const char *kMetricHttpClientResponseBodySize =
-    "metric.http.client.response.body.size";
+static constexpr const char *kMetricHttpClientResponseBodySize = "http.client.response.body.size";
 static constexpr const char *descrMetricHttpClientResponseBodySize =
     "Size of HTTP client response bodies.";
 static constexpr const char *unitMetricHttpClientResponseBodySize = "By";
@@ -224,7 +220,7 @@ CreateSyncDoubleMetricHttpClientResponseBodySize(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricHttpServerActiveRequests = "metric.http.server.active_requests";
+static constexpr const char *kMetricHttpServerActiveRequests = "http.server.active_requests";
 static constexpr const char *descrMetricHttpServerActiveRequests =
     "Number of active HTTP server requests.";
 static constexpr const char *unitMetricHttpServerActiveRequests = "{request}";
@@ -269,8 +265,7 @@ CreateAsyncDoubleMetricHttpServerActiveRequests(metrics::Meter *meter)
  * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
  * header. For requests using transport encoding, this should be the compressed size. <p> histogram
  */
-static constexpr const char *kMetricHttpServerRequestBodySize =
-    "metric.http.server.request.body.size";
+static constexpr const char *kMetricHttpServerRequestBodySize = "http.server.request.body.size";
 static constexpr const char *descrMetricHttpServerRequestBodySize =
     "Size of HTTP server request bodies.";
 static constexpr const char *unitMetricHttpServerRequestBodySize = "By";
@@ -296,8 +291,7 @@ CreateSyncDoubleMetricHttpServerRequestBodySize(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricHttpServerRequestDuration =
-    "metric.http.server.request.duration";
+static constexpr const char *kMetricHttpServerRequestDuration = "http.server.request.duration";
 static constexpr const char *descrMetricHttpServerRequestDuration =
     "Duration of HTTP server requests.";
 static constexpr const char *unitMetricHttpServerRequestDuration = "s";
@@ -326,8 +320,7 @@ CreateSyncDoubleMetricHttpServerRequestDuration(metrics::Meter *meter)
  * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
  * header. For requests using transport encoding, this should be the compressed size. <p> histogram
  */
-static constexpr const char *kMetricHttpServerResponseBodySize =
-    "metric.http.server.response.body.size";
+static constexpr const char *kMetricHttpServerResponseBodySize = "http.server.response.body.size";
 static constexpr const char *descrMetricHttpServerResponseBodySize =
     "Size of HTTP server response bodies.";
 static constexpr const char *unitMetricHttpServerResponseBodySize = "By";

--- a/api/include/opentelemetry/semconv/incubating/hw_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/hw_metrics.h
@@ -25,7 +25,7 @@ namespace hw
  * <p>
  * counter
  */
-static constexpr const char *kMetricHwEnergy     = "metric.hw.energy";
+static constexpr const char *kMetricHwEnergy     = "hw.energy";
 static constexpr const char *descrMetricHwEnergy = "Energy consumed by the component";
 static constexpr const char *unitMetricHwEnergy  = "J";
 
@@ -60,7 +60,7 @@ static inline nostd::shared_ptr<metrics::ObservableInstrument> CreateAsyncDouble
  * <p>
  * counter
  */
-static constexpr const char *kMetricHwErrors     = "metric.hw.errors";
+static constexpr const char *kMetricHwErrors     = "hw.errors";
 static constexpr const char *descrMetricHwErrors = "Number of errors encountered by the component";
 static constexpr const char *unitMetricHwErrors  = "{error}";
 
@@ -96,7 +96,7 @@ static inline nostd::shared_ptr<metrics::ObservableInstrument> CreateAsyncDouble
  * It is recommended to report @code hw.energy @endcode instead of @code hw.power @endcode when
  * possible. <p> gauge
  */
-static constexpr const char *kMetricHwPower     = "metric.hw.power";
+static constexpr const char *kMetricHwPower     = "hw.power";
 static constexpr const char *descrMetricHwPower = "Instantaneous power consumed by the component";
 static constexpr const char *unitMetricHwPower  = "W";
 
@@ -138,7 +138,7 @@ static inline nostd::shared_ptr<metrics::ObservableInstrument> CreateAsyncDouble
  * way users query their timeseries backend to retrieve the values of @code hw.status @endcode over
  * time. <p> updowncounter
  */
-static constexpr const char *kMetricHwStatus = "metric.hw.status";
+static constexpr const char *kMetricHwStatus = "hw.status";
 static constexpr const char *descrMetricHwStatus =
     "Operational status: `1` (true) or `0` (false) for each of the possible states";
 static constexpr const char *unitMetricHwStatus = "1";

--- a/api/include/opentelemetry/semconv/incubating/k8s_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/k8s_metrics.h
@@ -27,7 +27,7 @@ namespace k8s
  * <p>
  * counter
  */
-static constexpr const char *kMetricK8sNodeCpuTime     = "metric.k8s.node.cpu.time";
+static constexpr const char *kMetricK8sNodeCpuTime     = "k8s.node.cpu.time";
 static constexpr const char *descrMetricK8sNodeCpuTime = "Total CPU time consumed";
 static constexpr const char *unitMetricK8sNodeCpuTime  = "s";
 
@@ -66,7 +66,7 @@ CreateAsyncDoubleMetricK8sNodeCpuTime(metrics::Meter *meter)
  * <p>
  * gauge
  */
-static constexpr const char *kMetricK8sNodeCpuUsage = "metric.k8s.node.cpu.usage";
+static constexpr const char *kMetricK8sNodeCpuUsage = "k8s.node.cpu.usage";
 static constexpr const char *descrMetricK8sNodeCpuUsage =
     "Node's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs";
 static constexpr const char *unitMetricK8sNodeCpuUsage = "{cpu}";
@@ -109,7 +109,7 @@ CreateAsyncDoubleMetricK8sNodeCpuUsage(metrics::Meter *meter)
  * <p>
  * gauge
  */
-static constexpr const char *kMetricK8sNodeMemoryUsage     = "metric.k8s.node.memory.usage";
+static constexpr const char *kMetricK8sNodeMemoryUsage     = "k8s.node.memory.usage";
 static constexpr const char *descrMetricK8sNodeMemoryUsage = "Memory usage of the Node";
 static constexpr const char *unitMetricK8sNodeMemoryUsage  = "By";
 
@@ -149,7 +149,7 @@ CreateAsyncDoubleMetricK8sNodeMemoryUsage(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricK8sNodeNetworkErrors     = "metric.k8s.node.network.errors";
+static constexpr const char *kMetricK8sNodeNetworkErrors     = "k8s.node.network.errors";
 static constexpr const char *descrMetricK8sNodeNetworkErrors = "Node network errors";
 static constexpr const char *unitMetricK8sNodeNetworkErrors  = "{error}";
 
@@ -186,7 +186,7 @@ CreateAsyncDoubleMetricK8sNodeNetworkErrors(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricK8sNodeNetworkIo     = "metric.k8s.node.network.io";
+static constexpr const char *kMetricK8sNodeNetworkIo     = "k8s.node.network.io";
 static constexpr const char *descrMetricK8sNodeNetworkIo = "Network bytes for the Node";
 static constexpr const char *unitMetricK8sNodeNetworkIo  = "By";
 
@@ -225,7 +225,7 @@ CreateAsyncDoubleMetricK8sNodeNetworkIo(metrics::Meter *meter)
  * as a floating point number with the highest precision available. The actual accuracy would depend
  * on the instrumentation and operating system. <p> gauge
  */
-static constexpr const char *kMetricK8sNodeUptime     = "metric.k8s.node.uptime";
+static constexpr const char *kMetricK8sNodeUptime     = "k8s.node.uptime";
 static constexpr const char *descrMetricK8sNodeUptime = "The time the Node has been running";
 static constexpr const char *unitMetricK8sNodeUptime  = "s";
 
@@ -267,7 +267,7 @@ static inline nostd::shared_ptr<metrics::ObservableInstrument> CreateAsyncDouble
  * <p>
  * counter
  */
-static constexpr const char *kMetricK8sPodCpuTime     = "metric.k8s.pod.cpu.time";
+static constexpr const char *kMetricK8sPodCpuTime     = "k8s.pod.cpu.time";
 static constexpr const char *descrMetricK8sPodCpuTime = "Total CPU time consumed";
 static constexpr const char *unitMetricK8sPodCpuTime  = "s";
 
@@ -306,7 +306,7 @@ static inline nostd::shared_ptr<metrics::ObservableInstrument> CreateAsyncDouble
  * <p>
  * gauge
  */
-static constexpr const char *kMetricK8sPodCpuUsage = "metric.k8s.pod.cpu.usage";
+static constexpr const char *kMetricK8sPodCpuUsage = "k8s.pod.cpu.usage";
 static constexpr const char *descrMetricK8sPodCpuUsage =
     "Pod's CPU usage, measured in cpus. Range from 0 to the number of allocatable CPUs";
 static constexpr const char *unitMetricK8sPodCpuUsage = "{cpu}";
@@ -349,7 +349,7 @@ CreateAsyncDoubleMetricK8sPodCpuUsage(metrics::Meter *meter)
  * <p>
  * gauge
  */
-static constexpr const char *kMetricK8sPodMemoryUsage     = "metric.k8s.pod.memory.usage";
+static constexpr const char *kMetricK8sPodMemoryUsage     = "k8s.pod.memory.usage";
 static constexpr const char *descrMetricK8sPodMemoryUsage = "Memory usage of the Pod";
 static constexpr const char *unitMetricK8sPodMemoryUsage  = "By";
 
@@ -389,7 +389,7 @@ CreateAsyncDoubleMetricK8sPodMemoryUsage(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricK8sPodNetworkErrors     = "metric.k8s.pod.network.errors";
+static constexpr const char *kMetricK8sPodNetworkErrors     = "k8s.pod.network.errors";
 static constexpr const char *descrMetricK8sPodNetworkErrors = "Pod network errors";
 static constexpr const char *unitMetricK8sPodNetworkErrors  = "{error}";
 
@@ -426,7 +426,7 @@ CreateAsyncDoubleMetricK8sPodNetworkErrors(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricK8sPodNetworkIo     = "metric.k8s.pod.network.io";
+static constexpr const char *kMetricK8sPodNetworkIo     = "k8s.pod.network.io";
 static constexpr const char *descrMetricK8sPodNetworkIo = "Network bytes for the Pod";
 static constexpr const char *unitMetricK8sPodNetworkIo  = "By";
 
@@ -465,7 +465,7 @@ CreateAsyncDoubleMetricK8sPodNetworkIo(metrics::Meter *meter)
  * as a floating point number with the highest precision available. The actual accuracy would depend
  * on the instrumentation and operating system. <p> gauge
  */
-static constexpr const char *kMetricK8sPodUptime     = "metric.k8s.pod.uptime";
+static constexpr const char *kMetricK8sPodUptime     = "k8s.pod.uptime";
 static constexpr const char *descrMetricK8sPodUptime = "The time the Pod has been running";
 static constexpr const char *unitMetricK8sPodUptime  = "s";
 

--- a/api/include/opentelemetry/semconv/incubating/messaging_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/messaging_metrics.h
@@ -30,7 +30,7 @@ namespace messaging
  * processed. <p> counter
  */
 static constexpr const char *kMetricMessagingClientConsumedMessages =
-    "metric.messaging.client.consumed.messages";
+    "messaging.client.consumed.messages";
 static constexpr const char *descrMetricMessagingClientConsumedMessages =
     "Number of messages that were delivered to the application.";
 static constexpr const char *unitMetricMessagingClientConsumedMessages = "{message}";
@@ -74,7 +74,7 @@ CreateAsyncDoubleMetricMessagingClientConsumedMessages(metrics::Meter *meter)
  * @code messaging.process.duration @endcode metric. <p> histogram
  */
 static constexpr const char *kMetricMessagingClientOperationDuration =
-    "metric.messaging.client.operation.duration";
+    "messaging.client.operation.duration";
 static constexpr const char *descrMetricMessagingClientOperationDuration =
     "Duration of messaging operation initiated by a producer or consumer client.";
 static constexpr const char *unitMetricMessagingClientOperationDuration = "s";
@@ -105,7 +105,7 @@ CreateSyncDoubleMetricMessagingClientOperationDuration(metrics::Meter *meter)
  */
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *kMetricMessagingClientPublishedMessages =
-    "metric.messaging.client.published.messages";
+    "messaging.client.published.messages";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricMessagingClientPublishedMessages =
     "Deprecated. Use `messaging.client.sent.messages` instead.";
@@ -155,8 +155,7 @@ CreateAsyncDoubleMetricMessagingClientPublishedMessages(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricMessagingClientSentMessages =
-    "metric.messaging.client.sent.messages";
+static constexpr const char *kMetricMessagingClientSentMessages = "messaging.client.sent.messages";
 static constexpr const char *descrMetricMessagingClientSentMessages =
     "Number of messages producer attempted to send to the broker.";
 static constexpr const char *unitMetricMessagingClientSentMessages = "{message}";
@@ -199,7 +198,7 @@ CreateAsyncDoubleMetricMessagingClientSentMessages(metrics::Meter *meter)
  * This metric MUST be reported for operations with @code messaging.operation.type @endcode that
  * matches @code process @endcode. <p> histogram
  */
-static constexpr const char *kMetricMessagingProcessDuration = "metric.messaging.process.duration";
+static constexpr const char *kMetricMessagingProcessDuration = "messaging.process.duration";
 static constexpr const char *descrMetricMessagingProcessDuration =
     "Duration of processing operation.";
 static constexpr const char *unitMetricMessagingProcessDuration = "s";
@@ -229,7 +228,7 @@ CreateSyncDoubleMetricMessagingProcessDuration(metrics::Meter *meter)
  * counter
  */
 OPENTELEMETRY_DEPRECATED
-static constexpr const char *kMetricMessagingProcessMessages = "metric.messaging.process.messages";
+static constexpr const char *kMetricMessagingProcessMessages = "messaging.process.messages";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricMessagingProcessMessages =
     "Deprecated. Use `messaging.client.consumed.messages` instead.";
@@ -281,7 +280,7 @@ CreateAsyncDoubleMetricMessagingProcessMessages(metrics::Meter *meter)
  * histogram
  */
 OPENTELEMETRY_DEPRECATED
-static constexpr const char *kMetricMessagingPublishDuration = "metric.messaging.publish.duration";
+static constexpr const char *kMetricMessagingPublishDuration = "messaging.publish.duration";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricMessagingPublishDuration =
     "Deprecated. Use `messaging.client.operation.duration` instead.";
@@ -315,7 +314,7 @@ CreateSyncDoubleMetricMessagingPublishDuration(metrics::Meter *meter)
  * counter
  */
 OPENTELEMETRY_DEPRECATED
-static constexpr const char *kMetricMessagingPublishMessages = "metric.messaging.publish.messages";
+static constexpr const char *kMetricMessagingPublishMessages = "messaging.publish.messages";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricMessagingPublishMessages =
     "Deprecated. Use `messaging.client.produced.messages` instead.";
@@ -367,7 +366,7 @@ CreateAsyncDoubleMetricMessagingPublishMessages(metrics::Meter *meter)
  * histogram
  */
 OPENTELEMETRY_DEPRECATED
-static constexpr const char *kMetricMessagingReceiveDuration = "metric.messaging.receive.duration";
+static constexpr const char *kMetricMessagingReceiveDuration = "messaging.receive.duration";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricMessagingReceiveDuration =
     "Deprecated. Use `messaging.client.operation.duration` instead.";
@@ -401,7 +400,7 @@ CreateSyncDoubleMetricMessagingReceiveDuration(metrics::Meter *meter)
  * counter
  */
 OPENTELEMETRY_DEPRECATED
-static constexpr const char *kMetricMessagingReceiveMessages = "metric.messaging.receive.messages";
+static constexpr const char *kMetricMessagingReceiveMessages = "messaging.receive.messages";
 OPENTELEMETRY_DEPRECATED
 static constexpr const char *descrMetricMessagingReceiveMessages =
     "Deprecated. Use `messaging.client.consumed.messages` instead.";

--- a/api/include/opentelemetry/semconv/incubating/process_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/process_metrics.h
@@ -25,7 +25,7 @@ namespace process
  * <p>
  * counter
  */
-static constexpr const char *kMetricProcessContextSwitches = "metric.process.context_switches";
+static constexpr const char *kMetricProcessContextSwitches = "process.context_switches";
 static constexpr const char *descrMetricProcessContextSwitches =
     "Number of times the process has been context switched.";
 static constexpr const char *unitMetricProcessContextSwitches = "{count}";
@@ -67,7 +67,7 @@ CreateAsyncDoubleMetricProcessContextSwitches(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricProcessCpuTime = "metric.process.cpu.time";
+static constexpr const char *kMetricProcessCpuTime = "process.cpu.time";
 static constexpr const char *descrMetricProcessCpuTime =
     "Total CPU seconds broken down by different states.";
 static constexpr const char *unitMetricProcessCpuTime = "s";
@@ -104,7 +104,7 @@ CreateAsyncDoubleMetricProcessCpuTime(metrics::Meter *meter)
  * Difference in process.cpu.time since the last measurement, divided by the elapsed time and number
  * of CPUs available to the process. <p> gauge
  */
-static constexpr const char *kMetricProcessCpuUtilization = "metric.process.cpu.utilization";
+static constexpr const char *kMetricProcessCpuUtilization = "process.cpu.utilization";
 static constexpr const char *descrMetricProcessCpuUtilization =
     "Difference in process.cpu.time since the last measurement, divided by the elapsed time and "
     "number of CPUs available to the process.";
@@ -148,7 +148,7 @@ CreateAsyncDoubleMetricProcessCpuUtilization(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricProcessDiskIo     = "metric.process.disk.io";
+static constexpr const char *kMetricProcessDiskIo     = "process.disk.io";
 static constexpr const char *descrMetricProcessDiskIo = "Disk bytes transferred.";
 static constexpr const char *unitMetricProcessDiskIo  = "By";
 
@@ -185,7 +185,7 @@ static inline nostd::shared_ptr<metrics::ObservableInstrument> CreateAsyncDouble
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricProcessMemoryUsage = "metric.process.memory.usage";
+static constexpr const char *kMetricProcessMemoryUsage = "process.memory.usage";
 static constexpr const char *descrMetricProcessMemoryUsage =
     "The amount of physical memory in use.";
 static constexpr const char *unitMetricProcessMemoryUsage = "By";
@@ -223,7 +223,7 @@ CreateAsyncDoubleMetricProcessMemoryUsage(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricProcessMemoryVirtual = "metric.process.memory.virtual";
+static constexpr const char *kMetricProcessMemoryVirtual = "process.memory.virtual";
 static constexpr const char *descrMetricProcessMemoryVirtual =
     "The amount of committed virtual memory.";
 static constexpr const char *unitMetricProcessMemoryVirtual = "By";
@@ -261,7 +261,7 @@ CreateAsyncDoubleMetricProcessMemoryVirtual(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricProcessNetworkIo     = "metric.process.network.io";
+static constexpr const char *kMetricProcessNetworkIo     = "process.network.io";
 static constexpr const char *descrMetricProcessNetworkIo = "Network bytes transferred.";
 static constexpr const char *unitMetricProcessNetworkIo  = "By";
 
@@ -299,7 +299,7 @@ CreateAsyncDoubleMetricProcessNetworkIo(metrics::Meter *meter)
  * updowncounter
  */
 static constexpr const char *kMetricProcessOpenFileDescriptorCount =
-    "metric.process.open_file_descriptor.count";
+    "process.open_file_descriptor.count";
 static constexpr const char *descrMetricProcessOpenFileDescriptorCount =
     "Number of file descriptors in use by the process.";
 static constexpr const char *unitMetricProcessOpenFileDescriptorCount = "{count}";
@@ -341,7 +341,7 @@ CreateAsyncDoubleMetricProcessOpenFileDescriptorCount(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricProcessPagingFaults = "metric.process.paging.faults";
+static constexpr const char *kMetricProcessPagingFaults = "process.paging.faults";
 static constexpr const char *descrMetricProcessPagingFaults =
     "Number of page faults the process has made.";
 static constexpr const char *unitMetricProcessPagingFaults = "{fault}";
@@ -379,7 +379,7 @@ CreateAsyncDoubleMetricProcessPagingFaults(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricProcessThreadCount     = "metric.process.thread.count";
+static constexpr const char *kMetricProcessThreadCount     = "process.thread.count";
 static constexpr const char *descrMetricProcessThreadCount = "Process threads count.";
 static constexpr const char *unitMetricProcessThreadCount  = "{thread}";
 
@@ -418,7 +418,7 @@ CreateAsyncDoubleMetricProcessThreadCount(metrics::Meter *meter)
  * as a floating point number with the highest precision available. The actual accuracy would depend
  * on the instrumentation and operating system. <p> gauge
  */
-static constexpr const char *kMetricProcessUptime     = "metric.process.uptime";
+static constexpr const char *kMetricProcessUptime     = "process.uptime";
 static constexpr const char *descrMetricProcessUptime = "The time the process has been running.";
 static constexpr const char *unitMetricProcessUptime  = "s";
 

--- a/api/include/opentelemetry/semconv/incubating/rpc_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/rpc_metrics.h
@@ -30,7 +30,7 @@ namespace rpc
  * <p>
  * histogram
  */
-static constexpr const char *kMetricRpcClientDuration = "metric.rpc.client.duration";
+static constexpr const char *kMetricRpcClientDuration = "rpc.client.duration";
 static constexpr const char *descrMetricRpcClientDuration =
     "Measures the duration of outbound RPC.";
 static constexpr const char *unitMetricRpcClientDuration = "ms";
@@ -56,7 +56,7 @@ static inline nostd::unique_ptr<metrics::Histogram<double>> CreateSyncDoubleMetr
  * <p>
  * histogram
  */
-static constexpr const char *kMetricRpcClientRequestSize = "metric.rpc.client.request.size";
+static constexpr const char *kMetricRpcClientRequestSize = "rpc.client.request.size";
 static constexpr const char *descrMetricRpcClientRequestSize =
     "Measures the size of RPC request messages (uncompressed).";
 static constexpr const char *unitMetricRpcClientRequestSize = "By";
@@ -84,7 +84,7 @@ CreateSyncDoubleMetricRpcClientRequestSize(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricRpcClientRequestsPerRpc = "metric.rpc.client.requests_per_rpc";
+static constexpr const char *kMetricRpcClientRequestsPerRpc = "rpc.client.requests_per_rpc";
 static constexpr const char *descrMetricRpcClientRequestsPerRpc =
     "Measures the number of messages received per RPC.";
 static constexpr const char *unitMetricRpcClientRequestsPerRpc = "{count}";
@@ -112,7 +112,7 @@ CreateSyncDoubleMetricRpcClientRequestsPerRpc(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricRpcClientResponseSize = "metric.rpc.client.response.size";
+static constexpr const char *kMetricRpcClientResponseSize = "rpc.client.response.size";
 static constexpr const char *descrMetricRpcClientResponseSize =
     "Measures the size of RPC response messages (uncompressed).";
 static constexpr const char *unitMetricRpcClientResponseSize = "By";
@@ -142,8 +142,7 @@ CreateSyncDoubleMetricRpcClientResponseSize(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricRpcClientResponsesPerRpc =
-    "metric.rpc.client.responses_per_rpc";
+static constexpr const char *kMetricRpcClientResponsesPerRpc = "rpc.client.responses_per_rpc";
 static constexpr const char *descrMetricRpcClientResponsesPerRpc =
     "Measures the number of messages sent per RPC.";
 static constexpr const char *unitMetricRpcClientResponsesPerRpc = "{count}";
@@ -174,7 +173,7 @@ CreateSyncDoubleMetricRpcClientResponsesPerRpc(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricRpcServerDuration     = "metric.rpc.server.duration";
+static constexpr const char *kMetricRpcServerDuration     = "rpc.server.duration";
 static constexpr const char *descrMetricRpcServerDuration = "Measures the duration of inbound RPC.";
 static constexpr const char *unitMetricRpcServerDuration  = "ms";
 
@@ -199,7 +198,7 @@ static inline nostd::unique_ptr<metrics::Histogram<double>> CreateSyncDoubleMetr
  * <p>
  * histogram
  */
-static constexpr const char *kMetricRpcServerRequestSize = "metric.rpc.server.request.size";
+static constexpr const char *kMetricRpcServerRequestSize = "rpc.server.request.size";
 static constexpr const char *descrMetricRpcServerRequestSize =
     "Measures the size of RPC request messages (uncompressed).";
 static constexpr const char *unitMetricRpcServerRequestSize = "By";
@@ -227,7 +226,7 @@ CreateSyncDoubleMetricRpcServerRequestSize(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricRpcServerRequestsPerRpc = "metric.rpc.server.requests_per_rpc";
+static constexpr const char *kMetricRpcServerRequestsPerRpc = "rpc.server.requests_per_rpc";
 static constexpr const char *descrMetricRpcServerRequestsPerRpc =
     "Measures the number of messages received per RPC.";
 static constexpr const char *unitMetricRpcServerRequestsPerRpc = "{count}";
@@ -255,7 +254,7 @@ CreateSyncDoubleMetricRpcServerRequestsPerRpc(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricRpcServerResponseSize = "metric.rpc.server.response.size";
+static constexpr const char *kMetricRpcServerResponseSize = "rpc.server.response.size";
 static constexpr const char *descrMetricRpcServerResponseSize =
     "Measures the size of RPC response messages (uncompressed).";
 static constexpr const char *unitMetricRpcServerResponseSize = "By";
@@ -285,8 +284,7 @@ CreateSyncDoubleMetricRpcServerResponseSize(metrics::Meter *meter)
  * <p>
  * histogram
  */
-static constexpr const char *kMetricRpcServerResponsesPerRpc =
-    "metric.rpc.server.responses_per_rpc";
+static constexpr const char *kMetricRpcServerResponsesPerRpc = "rpc.server.responses_per_rpc";
 static constexpr const char *descrMetricRpcServerResponsesPerRpc =
     "Measures the number of messages sent per RPC.";
 static constexpr const char *unitMetricRpcServerResponsesPerRpc = "{count}";

--- a/api/include/opentelemetry/semconv/incubating/system_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/system_metrics.h
@@ -25,7 +25,7 @@ namespace system
  * <p>
  * gauge
  */
-static constexpr const char *kMetricSystemCpuFrequency = "metric.system.cpu.frequency";
+static constexpr const char *kMetricSystemCpuFrequency = "system.cpu.frequency";
 static constexpr const char *descrMetricSystemCpuFrequency =
     "Reports the current frequency of the CPU in Hz";
 static constexpr const char *unitMetricSystemCpuFrequency = "{Hz}";
@@ -65,7 +65,7 @@ CreateAsyncDoubleMetricSystemCpuFrequency(metrics::Meter *meter)
  * Reports the number of logical (virtual) processor cores created by the operating system to manage
  * multitasking <p> updowncounter
  */
-static constexpr const char *kMetricSystemCpuLogicalCount = "metric.system.cpu.logical.count";
+static constexpr const char *kMetricSystemCpuLogicalCount = "system.cpu.logical.count";
 static constexpr const char *descrMetricSystemCpuLogicalCount =
     "Reports the number of logical (virtual) processor cores created by the operating system to "
     "manage multitasking";
@@ -108,7 +108,7 @@ CreateAsyncDoubleMetricSystemCpuLogicalCount(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricSystemCpuPhysicalCount = "metric.system.cpu.physical.count";
+static constexpr const char *kMetricSystemCpuPhysicalCount = "system.cpu.physical.count";
 static constexpr const char *descrMetricSystemCpuPhysicalCount =
     "Reports the number of actual physical processor cores on the hardware";
 static constexpr const char *unitMetricSystemCpuPhysicalCount = "{cpu}";
@@ -150,7 +150,7 @@ CreateAsyncDoubleMetricSystemCpuPhysicalCount(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricSystemCpuTime = "metric.system.cpu.time";
+static constexpr const char *kMetricSystemCpuTime = "system.cpu.time";
 static constexpr const char *descrMetricSystemCpuTime =
     "Seconds each logical CPU spent on each mode";
 static constexpr const char *unitMetricSystemCpuTime = "s";
@@ -187,7 +187,7 @@ static inline nostd::shared_ptr<metrics::ObservableInstrument> CreateAsyncDouble
  * Difference in system.cpu.time since the last measurement, divided by the elapsed time and number
  * of logical CPUs <p> gauge
  */
-static constexpr const char *kMetricSystemCpuUtilization = "metric.system.cpu.utilization";
+static constexpr const char *kMetricSystemCpuUtilization = "system.cpu.utilization";
 static constexpr const char *descrMetricSystemCpuUtilization =
     "Difference in system.cpu.time since the last measurement, divided by the elapsed time and "
     "number of logical CPUs";
@@ -227,7 +227,7 @@ CreateAsyncDoubleMetricSystemCpuUtilization(metrics::Meter *meter)
 /**
  * counter
  */
-static constexpr const char *kMetricSystemDiskIo     = "metric.system.disk.io";
+static constexpr const char *kMetricSystemDiskIo     = "system.disk.io";
 static constexpr const char *descrMetricSystemDiskIo = "";
 static constexpr const char *unitMetricSystemDiskIo  = "By";
 
@@ -272,7 +272,7 @@ static inline nostd::shared_ptr<metrics::ObservableInstrument> CreateAsyncDouble
  * </ul>
  * counter
  */
-static constexpr const char *kMetricSystemDiskIoTime     = "metric.system.disk.io_time";
+static constexpr const char *kMetricSystemDiskIoTime     = "system.disk.io_time";
 static constexpr const char *descrMetricSystemDiskIoTime = "Time disk spent activated";
 static constexpr const char *unitMetricSystemDiskIoTime  = "s";
 
@@ -309,7 +309,7 @@ CreateAsyncDoubleMetricSystemDiskIoTime(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricSystemDiskLimit     = "metric.system.disk.limit";
+static constexpr const char *kMetricSystemDiskLimit     = "system.disk.limit";
 static constexpr const char *descrMetricSystemDiskLimit = "The total storage capacity of the disk";
 static constexpr const char *unitMetricSystemDiskLimit  = "By";
 
@@ -344,7 +344,7 @@ CreateAsyncDoubleMetricSystemDiskLimit(metrics::Meter *meter)
 /**
  * counter
  */
-static constexpr const char *kMetricSystemDiskMerged     = "metric.system.disk.merged";
+static constexpr const char *kMetricSystemDiskMerged     = "system.disk.merged";
 static constexpr const char *descrMetricSystemDiskMerged = "";
 static constexpr const char *unitMetricSystemDiskMerged  = "{operation}";
 
@@ -387,7 +387,7 @@ CreateAsyncDoubleMetricSystemDiskMerged(metrics::Meter *meter)
  * </ul>
  * counter
  */
-static constexpr const char *kMetricSystemDiskOperationTime = "metric.system.disk.operation_time";
+static constexpr const char *kMetricSystemDiskOperationTime = "system.disk.operation_time";
 static constexpr const char *descrMetricSystemDiskOperationTime =
     "Sum of the time each operation took to complete";
 static constexpr const char *unitMetricSystemDiskOperationTime = "s";
@@ -427,7 +427,7 @@ CreateAsyncDoubleMetricSystemDiskOperationTime(metrics::Meter *meter)
 /**
  * counter
  */
-static constexpr const char *kMetricSystemDiskOperations     = "metric.system.disk.operations";
+static constexpr const char *kMetricSystemDiskOperations     = "system.disk.operations";
 static constexpr const char *descrMetricSystemDiskOperations = "";
 static constexpr const char *unitMetricSystemDiskOperations  = "{operation}";
 
@@ -464,7 +464,7 @@ CreateAsyncDoubleMetricSystemDiskOperations(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricSystemFilesystemLimit = "metric.system.filesystem.limit";
+static constexpr const char *kMetricSystemFilesystemLimit = "system.filesystem.limit";
 static constexpr const char *descrMetricSystemFilesystemLimit =
     "The total storage capacity of the filesystem";
 static constexpr const char *unitMetricSystemFilesystemLimit = "By";
@@ -508,7 +508,7 @@ CreateAsyncDoubleMetricSystemFilesystemLimit(metrics::Meter *meter)
  * system.filesystem.state @endcode attributes SHOULD equal the total storage capacity of the
  * filesystem, that is @code system.filesystem.limit @endcode. <p> updowncounter
  */
-static constexpr const char *kMetricSystemFilesystemUsage = "metric.system.filesystem.usage";
+static constexpr const char *kMetricSystemFilesystemUsage = "system.filesystem.usage";
 static constexpr const char *descrMetricSystemFilesystemUsage =
     "Reports a filesystem's space usage across different states.";
 static constexpr const char *unitMetricSystemFilesystemUsage = "By";
@@ -548,8 +548,7 @@ CreateAsyncDoubleMetricSystemFilesystemUsage(metrics::Meter *meter)
 /**
  * gauge
  */
-static constexpr const char *kMetricSystemFilesystemUtilization =
-    "metric.system.filesystem.utilization";
+static constexpr const char *kMetricSystemFilesystemUtilization = "system.filesystem.utilization";
 static constexpr const char *descrMetricSystemFilesystemUtilization = "";
 static constexpr const char *unitMetricSystemFilesystemUtilization  = "1";
 
@@ -597,8 +596,7 @@ CreateAsyncDoubleMetricSystemFilesystemUtilization(metrics::Meter *meter)
  * href="https://superuser.com/a/980821">here</a>. See also @code MemAvailable @endcode in <a
  * href="https://man7.org/linux/man-pages/man5/proc.5.html">/proc/meminfo</a>. <p> updowncounter
  */
-static constexpr const char *kMetricSystemLinuxMemoryAvailable =
-    "metric.system.linux.memory.available";
+static constexpr const char *kMetricSystemLinuxMemoryAvailable = "system.linux.memory.available";
 static constexpr const char *descrMetricSystemLinuxMemoryAvailable =
     "An estimate of how much memory is available for starting new applications, without causing "
     "swapping";
@@ -646,8 +644,7 @@ CreateAsyncDoubleMetricSystemLinuxMemoryAvailable(metrics::Meter *meter)
  * allocator</a> and @code Slab @endcode in <a
  * href="https://man7.org/linux/man-pages/man5/proc.5.html">/proc/meminfo</a>. <p> updowncounter
  */
-static constexpr const char *kMetricSystemLinuxMemorySlabUsage =
-    "metric.system.linux.memory.slab.usage";
+static constexpr const char *kMetricSystemLinuxMemorySlabUsage = "system.linux.memory.slab.usage";
 static constexpr const char *descrMetricSystemLinuxMemorySlabUsage =
     "Reports the memory used by the Linux kernel for managing caches of frequently used objects.";
 static constexpr const char *unitMetricSystemLinuxMemorySlabUsage = "By";
@@ -691,7 +688,7 @@ CreateAsyncDoubleMetricSystemLinuxMemorySlabUsage(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricSystemMemoryLimit     = "metric.system.memory.limit";
+static constexpr const char *kMetricSystemMemoryLimit     = "system.memory.limit";
 static constexpr const char *descrMetricSystemMemoryLimit = "Total memory available in the system.";
 static constexpr const char *unitMetricSystemMemoryLimit  = "By";
 
@@ -731,7 +728,7 @@ CreateAsyncDoubleMetricSystemMemoryLimit(metrics::Meter *meter)
  * @code Shmem @endcode from <a href="https://man7.org/linux/man-pages/man5/proc.5.html">@code
  * /proc/meminfo @endcode</a>" <p> updowncounter
  */
-static constexpr const char *kMetricSystemMemoryShared = "metric.system.memory.shared";
+static constexpr const char *kMetricSystemMemoryShared = "system.memory.shared";
 static constexpr const char *descrMetricSystemMemoryShared =
     "Shared memory used (mostly by tmpfs).";
 static constexpr const char *unitMetricSystemMemoryShared = "By";
@@ -772,7 +769,7 @@ CreateAsyncDoubleMetricSystemMemoryShared(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricSystemMemoryUsage     = "metric.system.memory.usage";
+static constexpr const char *kMetricSystemMemoryUsage     = "system.memory.usage";
 static constexpr const char *descrMetricSystemMemoryUsage = "Reports memory in use by state.";
 static constexpr const char *unitMetricSystemMemoryUsage  = "By";
 
@@ -807,7 +804,7 @@ CreateAsyncDoubleMetricSystemMemoryUsage(metrics::Meter *meter)
 /**
  * gauge
  */
-static constexpr const char *kMetricSystemMemoryUtilization = "metric.system.memory.utilization";
+static constexpr const char *kMetricSystemMemoryUtilization     = "system.memory.utilization";
 static constexpr const char *descrMetricSystemMemoryUtilization = "";
 static constexpr const char *unitMetricSystemMemoryUtilization  = "1";
 
@@ -848,7 +845,7 @@ CreateAsyncDoubleMetricSystemMemoryUtilization(metrics::Meter *meter)
 /**
  * updowncounter
  */
-static constexpr const char *kMetricSystemNetworkConnections = "metric.system.network.connections";
+static constexpr const char *kMetricSystemNetworkConnections     = "system.network.connections";
 static constexpr const char *descrMetricSystemNetworkConnections = "";
 static constexpr const char *unitMetricSystemNetworkConnections  = "{connection}";
 
@@ -899,7 +896,7 @@ CreateAsyncDoubleMetricSystemNetworkConnections(metrics::Meter *meter)
  * </ul>
  * counter
  */
-static constexpr const char *kMetricSystemNetworkDropped = "metric.system.network.dropped";
+static constexpr const char *kMetricSystemNetworkDropped = "system.network.dropped";
 static constexpr const char *descrMetricSystemNetworkDropped =
     "Count of packets that are dropped or discarded even though there was no error";
 static constexpr const char *unitMetricSystemNetworkDropped = "{packet}";
@@ -947,7 +944,7 @@ CreateAsyncDoubleMetricSystemNetworkDropped(metrics::Meter *meter)
  * </ul>
  * counter
  */
-static constexpr const char *kMetricSystemNetworkErrors     = "metric.system.network.errors";
+static constexpr const char *kMetricSystemNetworkErrors     = "system.network.errors";
 static constexpr const char *descrMetricSystemNetworkErrors = "Count of network errors detected";
 static constexpr const char *unitMetricSystemNetworkErrors  = "{error}";
 
@@ -982,7 +979,7 @@ CreateAsyncDoubleMetricSystemNetworkErrors(metrics::Meter *meter)
 /**
  * counter
  */
-static constexpr const char *kMetricSystemNetworkIo     = "metric.system.network.io";
+static constexpr const char *kMetricSystemNetworkIo     = "system.network.io";
 static constexpr const char *descrMetricSystemNetworkIo = "";
 static constexpr const char *unitMetricSystemNetworkIo  = "By";
 
@@ -1017,7 +1014,7 @@ CreateAsyncDoubleMetricSystemNetworkIo(metrics::Meter *meter)
 /**
  * counter
  */
-static constexpr const char *kMetricSystemNetworkPackets     = "metric.system.network.packets";
+static constexpr const char *kMetricSystemNetworkPackets     = "system.network.packets";
 static constexpr const char *descrMetricSystemNetworkPackets = "";
 static constexpr const char *unitMetricSystemNetworkPackets  = "{packet}";
 
@@ -1052,7 +1049,7 @@ CreateAsyncDoubleMetricSystemNetworkPackets(metrics::Meter *meter)
 /**
  * counter
  */
-static constexpr const char *kMetricSystemPagingFaults     = "metric.system.paging.faults";
+static constexpr const char *kMetricSystemPagingFaults     = "system.paging.faults";
 static constexpr const char *descrMetricSystemPagingFaults = "";
 static constexpr const char *unitMetricSystemPagingFaults  = "{fault}";
 
@@ -1087,7 +1084,7 @@ CreateAsyncDoubleMetricSystemPagingFaults(metrics::Meter *meter)
 /**
  * counter
  */
-static constexpr const char *kMetricSystemPagingOperations     = "metric.system.paging.operations";
+static constexpr const char *kMetricSystemPagingOperations     = "system.paging.operations";
 static constexpr const char *descrMetricSystemPagingOperations = "";
 static constexpr const char *unitMetricSystemPagingOperations  = "{operation}";
 
@@ -1128,7 +1125,7 @@ CreateAsyncDoubleMetricSystemPagingOperations(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricSystemPagingUsage     = "metric.system.paging.usage";
+static constexpr const char *kMetricSystemPagingUsage     = "system.paging.usage";
 static constexpr const char *descrMetricSystemPagingUsage = "Unix swap or windows pagefile usage";
 static constexpr const char *unitMetricSystemPagingUsage  = "By";
 
@@ -1163,7 +1160,7 @@ CreateAsyncDoubleMetricSystemPagingUsage(metrics::Meter *meter)
 /**
  * gauge
  */
-static constexpr const char *kMetricSystemPagingUtilization = "metric.system.paging.utilization";
+static constexpr const char *kMetricSystemPagingUtilization     = "system.paging.utilization";
 static constexpr const char *descrMetricSystemPagingUtilization = "";
 static constexpr const char *unitMetricSystemPagingUtilization  = "1";
 
@@ -1206,7 +1203,7 @@ CreateAsyncDoubleMetricSystemPagingUtilization(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricSystemProcessCount = "metric.system.process.count";
+static constexpr const char *kMetricSystemProcessCount = "system.process.count";
 static constexpr const char *descrMetricSystemProcessCount =
     "Total number of processes in each state";
 static constexpr const char *unitMetricSystemProcessCount = "{process}";
@@ -1244,7 +1241,7 @@ CreateAsyncDoubleMetricSystemProcessCount(metrics::Meter *meter)
  * <p>
  * counter
  */
-static constexpr const char *kMetricSystemProcessCreated = "metric.system.process.created";
+static constexpr const char *kMetricSystemProcessCreated = "system.process.created";
 static constexpr const char *descrMetricSystemProcessCreated =
     "Total number of processes created over uptime of the host";
 static constexpr const char *unitMetricSystemProcessCreated = "{process}";
@@ -1284,7 +1281,7 @@ CreateAsyncDoubleMetricSystemProcessCreated(metrics::Meter *meter)
  * as a floating point number with the highest precision available. The actual accuracy would depend
  * on the instrumentation and operating system. <p> gauge
  */
-static constexpr const char *kMetricSystemUptime     = "metric.system.uptime";
+static constexpr const char *kMetricSystemUptime     = "system.uptime";
 static constexpr const char *descrMetricSystemUptime = "The time the system has been running";
 static constexpr const char *unitMetricSystemUptime  = "s";
 

--- a/api/include/opentelemetry/semconv/incubating/vcs_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/vcs_metrics.h
@@ -24,7 +24,7 @@ namespace vcs
  * The number of changes (pull requests/merge requests/changelists) in a repository, categorized by
  * their state (e.g. open or merged) <p> updowncounter
  */
-static constexpr const char *kMetricVcsChangeCount = "metric.vcs.change.count";
+static constexpr const char *kMetricVcsChangeCount = "vcs.change.count";
 static constexpr const char *descrMetricVcsChangeCount =
     "The number of changes (pull requests/merge requests/changelists) in a repository, categorized "
     "by their state (e.g. open or merged)";
@@ -63,7 +63,7 @@ CreateAsyncDoubleMetricVcsChangeCount(metrics::Meter *meter)
  * <p>
  * gauge
  */
-static constexpr const char *kMetricVcsChangeDuration = "metric.vcs.change.duration";
+static constexpr const char *kMetricVcsChangeDuration = "vcs.change.duration";
 static constexpr const char *descrMetricVcsChangeDuration =
     "The time duration a change (pull request/merge request/changelist) has been in a given state.";
 static constexpr const char *unitMetricVcsChangeDuration = "s";
@@ -103,7 +103,7 @@ CreateAsyncDoubleMetricVcsChangeDuration(metrics::Meter *meter)
  * The amount of time since its creation it took a change (pull request/merge request/changelist) to
  * get the first approval <p> gauge
  */
-static constexpr const char *kMetricVcsChangeTimeToApproval = "metric.vcs.change.time_to_approval";
+static constexpr const char *kMetricVcsChangeTimeToApproval = "vcs.change.time_to_approval";
 static constexpr const char *descrMetricVcsChangeTimeToApproval =
     "The amount of time since its creation it took a change (pull request/merge "
     "request/changelist) to get the first approval";
@@ -148,7 +148,7 @@ CreateAsyncDoubleMetricVcsChangeTimeToApproval(metrics::Meter *meter)
  * <p>
  * gauge
  */
-static constexpr const char *kMetricVcsContributorCount = "metric.vcs.contributor.count";
+static constexpr const char *kMetricVcsContributorCount = "vcs.contributor.count";
 static constexpr const char *descrMetricVcsContributorCount =
     "The number of unique contributors to a repository";
 static constexpr const char *unitMetricVcsContributorCount = "{contributor}";
@@ -189,7 +189,7 @@ CreateAsyncDoubleMetricVcsContributorCount(metrics::Meter *meter)
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricVcsRefCount = "metric.vcs.ref.count";
+static constexpr const char *kMetricVcsRefCount = "vcs.ref.count";
 static constexpr const char *descrMetricVcsRefCount =
     "The number of refs of type branch or tag in a repository";
 static constexpr const char *unitMetricVcsRefCount = "{ref}";
@@ -230,7 +230,7 @@ static inline nostd::shared_ptr<metrics::ObservableInstrument> CreateAsyncDouble
  * If number of lines added/removed should be calculated from the start of time, then @code
  * vcs.ref.base.name @endcode SHOULD be set to an empty string. <p> gauge
  */
-static constexpr const char *kMetricVcsRefLinesDelta = "metric.vcs.ref.lines_delta";
+static constexpr const char *kMetricVcsRefLinesDelta = "vcs.ref.lines_delta";
 static constexpr const char *descrMetricVcsRefLinesDelta =
     "The number of lines added/removed in a ref (branch) relative to the ref from the "
     "`vcs.ref.base.name` attribute";
@@ -275,7 +275,7 @@ CreateAsyncDoubleMetricVcsRefLinesDelta(metrics::Meter *meter)
  * measurements: 3 and 2 (both positive numbers) and @code vcs.ref.base.name @endcode is set to
  * @code trunk @endcode. <p> gauge
  */
-static constexpr const char *kMetricVcsRefRevisionsDelta = "metric.vcs.ref.revisions_delta";
+static constexpr const char *kMetricVcsRefRevisionsDelta = "vcs.ref.revisions_delta";
 static constexpr const char *descrMetricVcsRefRevisionsDelta =
     "The number of revisions (commits) a ref (branch) is ahead/behind the branch from the "
     "`vcs.ref.base.name` attribute";
@@ -316,7 +316,7 @@ CreateAsyncDoubleMetricVcsRefRevisionsDelta(metrics::Meter *meter)
  * Time a ref (branch) created from the default branch (trunk) has existed. The @code ref.type
  * @endcode attribute will always be @code branch @endcode <p> gauge
  */
-static constexpr const char *kMetricVcsRefTime = "metric.vcs.ref.time";
+static constexpr const char *kMetricVcsRefTime = "vcs.ref.time";
 static constexpr const char *descrMetricVcsRefTime =
     "Time a ref (branch) created from the default branch (trunk) has existed. The `ref.type` "
     "attribute will always be `branch`";
@@ -356,7 +356,7 @@ static inline nostd::shared_ptr<metrics::ObservableInstrument> CreateAsyncDouble
  * <p>
  * updowncounter
  */
-static constexpr const char *kMetricVcsRepositoryCount = "metric.vcs.repository.count";
+static constexpr const char *kMetricVcsRepositoryCount = "vcs.repository.count";
 static constexpr const char *descrMetricVcsRepositoryCount =
     "The number of repositories in an organization";
 static constexpr const char *unitMetricVcsRepositoryCount = "{repository}";

--- a/buildscripts/semantic-convention/templates/registry/semantic_metrics-h.j2
+++ b/buildscripts/semantic-convention/templates/registry/semantic_metrics-h.j2
@@ -142,7 +142,7 @@ OPENTELEMETRY_DEPRECATED
     {% else %}
 {{ [metric.brief, "\n", metric.note, "\n", metric.instrument] | comment(ident=2) }}
     {% endif %}
-static constexpr const char *{{v_metric_name}} = "{{metric.id}}";
+static constexpr const char *{{v_metric_name}} = "{{metric.metric_name}}";
     {% if metric is deprecated %}
 OPENTELEMETRY_DEPRECATED
     {% endif %}


### PR DESCRIPTION
Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed