### PR TITLE
[CMake] Add missing CMake keyword for target_link_libraries (#3442)

### DIFF
--- a/examples/otlp/CMakeLists.txt
+++ b/examples/otlp/CMakeLists.txt
@@ -115,7 +115,7 @@ if(WITH_OTLP_HTTP)
     target_compile_definitions(example_otlp_instrumented_http
                                PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
     target_link_libraries(example_otlp_instrumented_http
-                          opentelemetry-cpp::opentelemetry_cpp)
+                          PRIVATE opentelemetry-cpp::opentelemetry_cpp)
   else()
     target_link_libraries(
       example_otlp_instrumented_http


### PR DESCRIPTION
Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed