### PR TITLE
[SDK] Ensure TraceId is portable on big-endian architectures (#3543)

### DIFF
--- a/sdk/src/trace/samplers/trace_id_ratio.cc
+++ b/sdk/src/trace/samplers/trace_id_ratio.cc
@@ -4,11 +4,11 @@
 
 #include <cmath>
 #include <cstdint>
-#include <cstring>
 #include <map>
 #include <memory>
 #include <string>
 
+#include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/trace/sampler.h"
 #include "opentelemetry/sdk/trace/samplers/trace_id_ratio.h"
@@ -56,8 +56,13 @@ uint64_t CalculateThresholdFromBuffer(const trace_api::TraceId &trace_id) noexce
   // We only use the first 8 bytes of TraceId.
   static_assert(trace_api::TraceId::kSize >= 8, "TraceID must be at least 8 bytes long.");
 
-  uint64_t res = 0;
-  std::memcpy(&res, &trace_id, 8);
+  // Always interpret as big-endian
+  const uint8_t *data = trace_id.Id().data();
+  uint64_t res        = 0;
+  for (int i = 0; i < 8; ++i)
+  {
+    res = (res << 8) | data[i];
+  }
 
   double ratio = static_cast<double>(res) / static_cast<double>(UINT64_MAX);
 

--- a/sdk/test/trace/trace_id_ratio_sampler_test.cc
+++ b/sdk/test/trace/trace_id_ratio_sampler_test.cc
@@ -99,7 +99,7 @@ TEST(TraceIdRatioBasedSampler, ShouldSampleWithoutContext)
   ASSERT_EQ(Decision::RECORD_AND_SAMPLE, sampling_result.decision);
   ASSERT_EQ(nullptr, sampling_result.attributes);
 
-  constexpr uint8_t buf[] = {0, 0, 0, 0, 0, 0, 0, 0x80, 0, 0, 0, 0, 0, 0, 0, 0};
+  constexpr uint8_t buf[] = {0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   trace_api::TraceId valid_trace_id(buf);
 
   sampling_result = s1.ShouldSample(trace_api::SpanContext::GetInvalid(), valid_trace_id, "",


### PR DESCRIPTION
Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed