### PR TITLE
[CI] update do_ci scripts to use common cmake cache scripts (#3582)

### DIFF
--- a/ci/do_ci.ps1
+++ b/ci/do_ci.ps1
@@ -110,9 +110,8 @@ switch ($action) {
   "cmake.maintainer.test" {
     cd "$BUILD_DIR"
     cmake $SRC_DIR `
-      -DWITH_OTLP_GRPC=ON `
-      -DWITH_OTLP_HTTP=ON `
-      -DWITH_OTLP_RETRY_PREVIEW=ON `
+      "-C $SRC_DIR/test_common/cmake/all-options-abiv1-preview.cmake" `
+      -DWITH_OPENTRACING=OFF `
       -DOTELCPP_MAINTAINER_MODE=ON `
       -DWITH_NO_DEPRECATED_CODE=ON `
       -DVCPKG_TARGET_TRIPLET=x64-windows `
@@ -135,11 +134,10 @@ switch ($action) {
   "cmake.maintainer.cxx20.stl.test" {
     cd "$BUILD_DIR"
     cmake $SRC_DIR `
+      "-C $SRC_DIR/test_common/cmake/all-options-abiv1-preview.cmake" `
+      -DWITH_OPENTRACING=OFF `
       -DWITH_STL=CXX20 `
       -DCMAKE_CXX_STANDARD=20 `
-      -DWITH_OTLP_GRPC=ON `
-      -DWITH_OTLP_HTTP=ON `
-      -DWITH_OTLP_RETRY_PREVIEW=ON `
       -DOTELCPP_MAINTAINER_MODE=ON `
       -DWITH_NO_DEPRECATED_CODE=ON `
       -DVCPKG_TARGET_TRIPLET=x64-windows `
@@ -162,13 +160,10 @@ switch ($action) {
   "cmake.maintainer.abiv2.test" {
     cd "$BUILD_DIR"
     cmake $SRC_DIR `
-      -DWITH_OTLP_GRPC=ON `
-      -DWITH_OTLP_HTTP=ON `
-      -DWITH_OTLP_RETRY_PREVIEW=ON `
+      "-C $SRC_DIR/test_common/cmake/all-options-abiv2-preview.cmake" `
+      -DWITH_OPENTRACING=OFF `
       -DOTELCPP_MAINTAINER_MODE=ON `
       -DWITH_NO_DEPRECATED_CODE=ON `
-      -DWITH_ABI_VERSION_1=OFF `
-      -DWITH_ABI_VERSION_2=ON `
       -DVCPKG_TARGET_TRIPLET=x64-windows `
       "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_DIR/scripts/buildsystems/vcpkg.cmake"
     $exit = $LASTEXITCODE
@@ -210,11 +205,9 @@ switch ($action) {
   "cmake.exporter.otprotocol.test" {
     cd "$BUILD_DIR"
     cmake $SRC_DIR `
-      -DVCPKG_TARGET_TRIPLET=x64-windows `
-      -DWITH_OTLP_GRPC=ON `
-      -DWITH_OTLP_HTTP=ON `
-      -DWITH_OTLP_RETRY_PREVIEW=ON `
-      -DWITH_OTPROTCOL=ON `
+      "-C $SRC_DIR/test_common/cmake/all-options-abiv1-preview.cmake" `
+      -DWITH_OPENTRACING=OFF `
+      -DVCPKG_TARGET_TRIPLET=x64-windows `      
       "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_DIR/scripts/buildsystems/vcpkg.cmake"
     $exit = $LASTEXITCODE
     if ($exit -ne 0) {
@@ -257,9 +250,10 @@ switch ($action) {
   "cmake.exporter.otprotocol.with_async_export.test" {
     cd "$BUILD_DIR"
     cmake $SRC_DIR `
+      "-C $SRC_DIR/test_common/cmake/all-options-abiv1-preview.cmake" `
+      -DWITH_OPENTRACING=OFF `
       -DVCPKG_TARGET_TRIPLET=x64-windows `
       -DWITH_ASYNC_EXPORT_PREVIEW=ON `
-      -DWITH_OTPROTCOL=ON `
       "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_DIR/scripts/buildsystems/vcpkg.cmake"
     $exit = $LASTEXITCODE
     if ($exit -ne 0) {
@@ -342,27 +336,9 @@ switch ($action) {
     cmake $SRC_DIR `
       $CMAKE_OPTIONS `
       "-DCMAKE_INSTALL_PREFIX=$INSTALL_TEST_DIR" `
-      -DWITH_ABI_VERSION_1=OFF `
-      -DWITH_ABI_VERSION_2=ON `
+      "-C $SRC_DIR/test_common/cmake/all-options-abiv2-preview.cmake" `
+      -DWITH_OPENTRACING=OFF `
       -DWITH_GSL=ON `
-      -DWITH_THREAD_INSTRUMENTATION_PREVIEW=ON `
-      -DWITH_METRICS_EXEMPLAR_PREVIEW=ON `
-      -DWITH_ASYNC_EXPORT_PREVIEW=ON `
-      -DWITH_OTLP_GRPC_SSL_MTLS_PREVIEW=ON `
-      -DWITH_OTLP_GRPC_CREDENTIAL_PREVIEW=ON `
-      -DWITH_OTLP_RETRY_PREVIEW=ON `
-      -DWITH_OTLP_GRPC=ON `
-      -DWITH_OTLP_HTTP=ON `
-      -DWITH_OTLP_FILE=ON `
-      -DWITH_OTLP_HTTP_COMPRESSION=ON `
-      -DWITH_HTTP_CLIENT_CURL=ON `
-      -DWITH_PROMETHEUS=ON `
-      -DWITH_ZIPKIN=ON `
-      -DWITH_ELASTICSEARCH=ON `
-      -DWITH_ETW=ON `
-      -DWITH_EXAMPLES=ON `
-      -DWITH_EXAMPLES_HTTP=ON `
-      -DBUILD_W3CTRACECONTEXT_TEST=ON `
       -DOPENTELEMETRY_INSTALL=ON
 
     $exit = $LASTEXITCODE
@@ -447,13 +423,9 @@ switch ($action) {
     cmake $SRC_DIR `
       $CMAKE_OPTIONS `
       "-DCMAKE_INSTALL_PREFIX=$INSTALL_TEST_DIR" `
-      -DWITH_ABI_VERSION_1=ON `
-      -DWITH_ABI_VERSION_2=OFF `
-      -DWITH_THREAD_INSTRUMENTATION_PREVIEW=ON `
-      -DWITH_METRICS_EXEMPLAR_PREVIEW=ON `
-      -DWITH_ASYNC_EXPORT_PREVIEW=ON `
-      -DWITH_ETW=ON `
+      "-C $SRC_DIR/test_common/cmake/all-options-abiv1-preview.cmake" `
       -DOPENTELEMETRY_INSTALL=ON `
+      -DWITH_OPENTRACING=OFF `
       -DWITH_OTLP_GRPC_SSL_MTLS_PREVIEW=OFF `
       -DWITH_OTLP_GRPC_CREDENTIAL_PREVIEW=OFF `
       -DWITH_OTLP_RETRY_PREVIEW=OFF `
@@ -466,6 +438,7 @@ switch ($action) {
       -DWITH_ZIPKIN=OFF `
       -DWITH_ELASTICSEARCH=OFF `
       -DWITH_EXAMPLES=OFF `
+      -DWITH_EXAMPLES_HTTP=OFF
 
     $exit = $LASTEXITCODE
     if ($exit -ne 0) {

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -124,22 +124,11 @@ elif [[ "$1" == "cmake.maintainer.sync.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
-        -DWITH_OTLP_HTTP=ON \
-        -DWITH_OTLP_GRPC=ON \
-        -DWITH_OTLP_FILE=ON \
-        -DWITH_PROMETHEUS=ON \
-        -DWITH_EXAMPLES=ON \
-        -DWITH_EXAMPLES_HTTP=ON \
-        -DWITH_ZIPKIN=ON \
-        -DBUILD_W3CTRACECONTEXT_TEST=ON \
-        -DWITH_ELASTICSEARCH=ON \
-        -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
+        -C ${SRC_DIR}/test_common/cmake/all-options-abiv1-preview.cmake \
+        -DWITH_OPENTRACING=OFF \
         -DWITH_ASYNC_EXPORT_PREVIEW=OFF \
         -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_NO_DEPRECATED_CODE=ON \
-        -DWITH_OTLP_HTTP_COMPRESSION=ON \
-        -DWITH_OTLP_RETRY_PREVIEW=ON \
-        -DWITH_THREAD_INSTRUMENTATION_PREVIEW=ON \
         "${SRC_DIR}"
   eval "$MAKE_COMMAND"
   make test
@@ -148,22 +137,10 @@ elif [[ "$1" == "cmake.maintainer.async.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
-        -DWITH_OTLP_HTTP=ON \
-        -DWITH_OTLP_GRPC=ON \
-        -DWITH_OTLP_FILE=ON \
-        -DWITH_PROMETHEUS=ON \
-        -DWITH_EXAMPLES=ON \
-        -DWITH_EXAMPLES_HTTP=ON \
-        -DWITH_ZIPKIN=ON \
-        -DBUILD_W3CTRACECONTEXT_TEST=ON \
-        -DWITH_ELASTICSEARCH=ON \
-        -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
-        -DWITH_ASYNC_EXPORT_PREVIEW=ON \
+        -C ${SRC_DIR}/test_common/cmake/all-options-abiv1-preview.cmake \
+        -DWITH_OPENTRACING=OFF \
         -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_NO_DEPRECATED_CODE=ON \
-        -DWITH_OTLP_HTTP_COMPRESSION=ON \
-        -DWITH_OTLP_RETRY_PREVIEW=ON \
-        -DWITH_THREAD_INSTRUMENTATION_PREVIEW=ON \
         "${SRC_DIR}"
   eval "$MAKE_COMMAND"
   make test
@@ -173,21 +150,10 @@ elif [[ "$1" == "cmake.maintainer.cpp11.async.test" ]]; then
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
         -DCMAKE_CXX_STANDARD=11 \
-        -DWITH_OTLP_HTTP=ON \
-        -DWITH_OTLP_FILE=ON \
-        -DWITH_PROMETHEUS=ON \
-        -DWITH_EXAMPLES=ON \
-        -DWITH_EXAMPLES_HTTP=ON \
-        -DWITH_ZIPKIN=ON \
-        -DBUILD_W3CTRACECONTEXT_TEST=ON \
-        -DWITH_ELASTICSEARCH=ON \
-        -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
-        -DWITH_ASYNC_EXPORT_PREVIEW=ON \
+        -C ${SRC_DIR}/test_common/cmake/all-options-abiv1-preview.cmake \
+        -DWITH_OPENTRACING=OFF \
         -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_NO_DEPRECATED_CODE=ON \
-        -DWITH_OTLP_HTTP_COMPRESSION=ON \
-        -DWITH_OTLP_RETRY_PREVIEW=ON \
-        -DWITH_THREAD_INSTRUMENTATION_PREVIEW=ON \
         "${SRC_DIR}"
   make -k -j $(nproc)
   make test
@@ -196,24 +162,11 @@ elif [[ "$1" == "cmake.maintainer.abiv2.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
-        -DWITH_OTLP_HTTP=ON \
-        -DWITH_OTLP_GRPC=ON \
-        -DWITH_OTLP_FILE=ON \
-        -DWITH_PROMETHEUS=ON \
-        -DWITH_EXAMPLES=ON \
-        -DWITH_EXAMPLES_HTTP=ON \
-        -DWITH_ZIPKIN=ON \
-        -DBUILD_W3CTRACECONTEXT_TEST=ON \
-        -DWITH_ELASTICSEARCH=ON \
-        -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
+        -C ${SRC_DIR}/test_common/cmake/all-options-abiv2-preview.cmake \
+        -DWITH_OPENTRACING=OFF \
         -DWITH_ASYNC_EXPORT_PREVIEW=OFF \
         -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_NO_DEPRECATED_CODE=ON \
-        -DWITH_ABI_VERSION_1=OFF \
-        -DWITH_ABI_VERSION_2=ON \
-        -DWITH_OTLP_HTTP_COMPRESSION=ON \
-        -DWITH_OTLP_RETRY_PREVIEW=ON \
-        -DWITH_THREAD_INSTRUMENTATION_PREVIEW=ON \
         "${SRC_DIR}"
   eval "$MAKE_COMMAND"
   make test
@@ -465,25 +418,7 @@ elif [[ "$1" == "cmake.install.test" ]]; then
 
   cmake "${CMAKE_OPTIONS[@]}"  \
         -DCMAKE_INSTALL_PREFIX=${INSTALL_TEST_DIR} \
-        -DWITH_ABI_VERSION_1=OFF \
-        -DWITH_ABI_VERSION_2=ON \
-        -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
-        -DWITH_ASYNC_EXPORT_PREVIEW=ON \
-        -DWITH_THREAD_INSTRUMENTATION_PREVIEW=ON \
-        -DWITH_OTLP_GRPC_SSL_MTLS_PREVIEW=ON \
-        -DWITH_OTLP_GRPC_CREDENTIAL_PREVIEW=ON \
-        -DWITH_OTLP_RETRY_PREVIEW=ON \
-        -DWITH_OTLP_GRPC=ON \
-        -DWITH_OTLP_HTTP=ON \
-        -DWITH_OTLP_FILE=ON \
-        -DWITH_OTLP_HTTP_COMPRESSION=ON \
-        -DWITH_HTTP_CLIENT_CURL=ON \
-        -DWITH_PROMETHEUS=ON \
-        -DWITH_ZIPKIN=ON \
-        -DWITH_ELASTICSEARCH=ON \
-        -DWITH_EXAMPLES=ON \
-        -DWITH_EXAMPLES_HTTP=ON \
-        -DBUILD_W3CTRACECONTEXT_TEST=ON \
+        -C ${SRC_DIR}/test_common/cmake/all-options-abiv2-preview.cmake \
         -DOPENTELEMETRY_INSTALL=ON \
         "${SRC_DIR}"
 
@@ -533,25 +468,7 @@ elif [[ "$1" == "cmake.fetch_content.test" ]]; then
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
         -DCMAKE_INSTALL_PREFIX=${INSTALL_TEST_DIR} \
-        -DWITH_ABI_VERSION_1=OFF \
-        -DWITH_ABI_VERSION_2=ON \
-        -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
-        -DWITH_ASYNC_EXPORT_PREVIEW=ON \
-        -DWITH_THREAD_INSTRUMENTATION_PREVIEW=ON \
-        -DWITH_OTLP_GRPC_SSL_MTLS_PREVIEW=ON \
-        -DWITH_OTLP_GRPC_CREDENTIAL_PREVIEW=ON \
-        -DWITH_OTLP_RETRY_PREVIEW=ON \
-        -DWITH_OTLP_GRPC=ON \
-        -DWITH_OTLP_HTTP=ON \
-        -DWITH_OTLP_FILE=ON \
-        -DWITH_OTLP_HTTP_COMPRESSION=ON \
-        -DWITH_HTTP_CLIENT_CURL=ON \
-        -DWITH_PROMETHEUS=ON \
-        -DWITH_ZIPKIN=ON \
-        -DWITH_ELASTICSEARCH=ON \
-        -DWITH_EXAMPLES=ON \
-        -DWITH_EXAMPLES_HTTP=ON \
-        -DBUILD_W3CTRACECONTEXT_TEST=ON \
+        -C ${SRC_DIR}/test_common/cmake/all-options-abiv2-preview.cmake \
         -DOPENTELEMETRY_INSTALL=OFF \
         -DOPENTELEMETRY_CPP_SRC_DIR="${SRC_DIR}" \
         "${SRC_DIR}/install/test/cmake/fetch_content_test"

--- a/exporters/otlp/test/otlp_file_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_file_metric_exporter_test.cc
@@ -95,8 +95,9 @@ public:
         opentelemetry::sdk::resource::ResourceAttributes{}, "resource_url");
     data.resource_ = &resource;
 
-    auto scope = opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create(
-        "library_name", "1.5.0", "scope_url", {{"scope_key", "scope_value"}});
+    auto instrumentation_scope =
+        opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create(
+            "library_name", "1.5.0", "scope_url", {{"scope_key", "scope_value"}});
 
     opentelemetry::sdk::metrics::MetricData metric_data{
         opentelemetry::sdk::metrics::InstrumentDescriptor{
@@ -110,7 +111,8 @@ public:
             {opentelemetry::sdk::metrics::PointAttributes{{"a2", "b2"}}, sum_point_data2}}};
 
     data.scope_metric_data_ = std::vector<opentelemetry::sdk::metrics::ScopeMetrics>{
-        {scope.get(), std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
+        {instrumentation_scope.get(),
+         std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
 
     auto result = exporter->Export(data);
     EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
@@ -180,10 +182,12 @@ public:
     auto resource = opentelemetry::sdk::resource::Resource::Create(
         opentelemetry::sdk::resource::ResourceAttributes{});
     data.resource_ = &resource;
-    auto scope     = opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create(
-        "library_name", "1.5.0");
+    auto instrumentation_scope =
+        opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("library_name",
+                                                                               "1.5.0");
     data.scope_metric_data_ = std::vector<opentelemetry::sdk::metrics::ScopeMetrics>{
-        {scope.get(), std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
+        {instrumentation_scope.get(),
+         std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
 
     auto result = exporter->Export(data);
     EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
@@ -250,10 +254,12 @@ public:
     auto resource = opentelemetry::sdk::resource::Resource::Create(
         opentelemetry::sdk::resource::ResourceAttributes{});
     data.resource_ = &resource;
-    auto scope     = opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create(
-        "library_name", "1.5.0");
+    auto instrumentation_scope =
+        opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("library_name",
+                                                                               "1.5.0");
     data.scope_metric_data_ = std::vector<opentelemetry::sdk::metrics::ScopeMetrics>{
-        {scope.get(), std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
+        {instrumentation_scope.get(),
+         std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
 
     auto result = exporter->Export(data);
     EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);

--- a/exporters/prometheus/test/exporter_utils_test.cc
+++ b/exporters/prometheus/test/exporter_utils_test.cc
@@ -102,18 +102,21 @@ void assert_basic(prometheus_client::MetricFamily &metric,
   switch (type)
   {
     case prometheus_client::MetricType::Counter: {
-      ASSERT_DOUBLE_EQ(metric_data.counter.value, vals[0]);
+      ASSERT_DOUBLE_EQ(static_cast<double>(metric_data.counter.value),
+                       static_cast<double>(vals[0]));
       break;
     }
     case prometheus_client::MetricType::Histogram: {
-      ASSERT_DOUBLE_EQ(metric_data.histogram.sample_count, vals[0]);
-      ASSERT_DOUBLE_EQ(metric_data.histogram.sample_sum, vals[1]);
+      ASSERT_DOUBLE_EQ(static_cast<double>(metric_data.histogram.sample_count),
+                       static_cast<double>(vals[0]));
+      ASSERT_DOUBLE_EQ(static_cast<double>(metric_data.histogram.sample_sum),
+                       static_cast<double>(vals[1]));
       auto buckets = metric_data.histogram.bucket;
       ASSERT_EQ(buckets.size(), vals[2]);
       break;
     }
     case prometheus_client::MetricType::Gauge: {
-      ASSERT_DOUBLE_EQ(metric_data.gauge.value, vals[0]);
+      ASSERT_DOUBLE_EQ(static_cast<double>(metric_data.gauge.value), static_cast<double>(vals[0]));
       break;
     }
     break;

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -101,13 +101,13 @@ int deflateInPlace(z_stream *strm, unsigned char *buf, uint32_t len, uint32_t *m
     have           = 0;
     while (ret == Z_OK)
     {
-      strm->avail_out =
-          strm->avail_in ? strm->next_in - strm->next_out : (buf + *max_len) - strm->next_out;
+      strm->avail_out = static_cast<decltype(z_stream::avail_out)>(
+          strm->avail_in ? strm->next_in - strm->next_out : (buf + *max_len) - strm->next_out);
       ret = deflate(strm, Z_FINISH);
     }
     if (ret != Z_BUF_ERROR || strm->avail_in == 0)
     {
-      *max_len = strm->next_out - buf;
+      *max_len = static_cast<uint32_t>(strm->next_out - buf);
       return ret == Z_STREAM_END ? Z_OK : ret;
     }
   }
@@ -130,10 +130,10 @@ int deflateInPlace(z_stream *strm, unsigned char *buf, uint32_t len, uint32_t *m
     std::memcpy(buf, temp.data(), have);
     strm->next_out = buf + have;
   }
-  strm->avail_out = (buf + *max_len) - strm->next_out;
+  strm->avail_out = static_cast<decltype(z_stream::avail_out)>((buf + *max_len) - strm->next_out);
   ret             = deflate(strm, Z_FINISH);
   strm->zfree(strm->opaque, hold);
-  *max_len = strm->next_out - buf;
+  *max_len = static_cast<uint32_t>(strm->next_out - buf);
   return ret == Z_OK ? Z_BUF_ERROR : (ret == Z_STREAM_END ? Z_OK : ret);
 }
 #endif  // ENABLE_OTLP_COMPRESSION_PREVIEW

--- a/ext/test/w3c_tracecontext_http_test_server/main.cc
+++ b/ext/test/w3c_tracecontext_http_test_server/main.cc
@@ -119,7 +119,7 @@ struct Uri
     size_t port_end = uri.substr(host_end + 1, std::string::npos).find('/');
 
     host = uri.substr(0, host_end + 7);
-    port = std::stoi(uri.substr(7 + host_end + 1, port_end));
+    port = static_cast<uint16_t>(std::stoi(uri.substr(7 + host_end + 1, port_end)));
     path = uri.substr(host_end + port_end + 2, std::string::npos);
   }
 };
@@ -185,7 +185,7 @@ int main(int argc, char *argv[])
   // The port the validation service listens to can be specified via the command line.
   if (argc > 1)
   {
-    port = atoi(argv[1]);
+    port = static_cast<uint16_t>(atoi(argv[1]));
   }
   else
   {


### PR DESCRIPTION
* update ci scripts to use the test_common/cmake cache variable scripts

* re-disable opentracing for maintainer tests

* fix ci issues. Maintainer build warnings on windows. CMake configure failure with dll build

* fix ci issues. W3C trace context test warnings failing windows maintainer builds

---------

Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed