### PR TITLE
[CMAKE] Fix CMake 4.x build error on MacOS runner and when building o…

### DIFF
--- a/.github/workflows/cmake_install.yml
+++ b/.github/workflows/cmake_install.yml
@@ -262,6 +262,7 @@ jobs:
       INSTALL_TEST_DIR: '/Users/runner/install_test'
       CXX_STANDARD: '17'
       CMAKE_TOOLCHAIN_FILE: '/Users/runner/conan/build/Debug/generators/conan_toolchain.cmake'
+      CMAKE_VERSION: 3.31.0 # building the conan "stable" versions requires CMake 3.x
       BUILD_TYPE: 'Debug'
     steps:
     - name: Harden the runner (Audit all outbound calls)
@@ -272,6 +273,9 @@ jobs:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         submodules: 'recursive'
+    - name: Install CMake
+      run: |
+        ./ci/setup_cmake_macos.sh
     - name: Install Conan and tools
       run: |
         brew install conan autoconf automake libtool coreutils

--- a/cmake/opentracing-cpp.cmake
+++ b/cmake/opentracing-cpp.cmake
@@ -27,9 +27,14 @@ if(NOT OpenTracing_FOUND)
     set(_SAVED_BUILD_TESTING ${BUILD_TESTING})
   endif()
 
+  if(DEFINED CMAKE_POLICY_VERSION_MINIMUM)
+    set(_SAVED_CMAKE_POLICY_VERSION_MINIMUM ${CMAKE_POLICY_VERSION_MINIMUM})
+  endif()
+
   # Set the cache variables for the opentracing build
   set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
   set(BUILD_MOCKTRACER OFF CACHE BOOL "" FORCE)
+  set(CMAKE_POLICY_VERSION_MINIMUM "3.5" CACHE STRING "" FORCE)
 
   FetchContent_MakeAvailable(opentracing)
 
@@ -38,6 +43,13 @@ if(NOT OpenTracing_FOUND)
     set(BUILD_TESTING ${_SAVED_BUILD_TESTING} CACHE BOOL "" FORCE)
   else()
     unset(BUILD_TESTING CACHE)
+  endif()
+
+  # Restore the saved state of CMAKE_POLICY_VERSION_MINIMUM
+  if(DEFINED _SAVED_CMAKE_POLICY_VERSION_MINIMUM)
+    set(CMAKE_POLICY_VERSION_MINIMUM ${_SAVED_CMAKE_POLICY_VERSION_MINIMUM} CACHE STRING "" FORCE)
+  else()
+    unset(CMAKE_POLICY_VERSION_MINIMUM CACHE)
   endif()
 
   # Patch the opentracing targets to set missing includes, add namespaced alias targets, disable iwyu and clang-tidy.


### PR DESCRIPTION
…pentracing  (#3649)

* set the CMAKE_POLICY_VERSION_MINIMUM=3.5 as a cache variable and environment variable when building opentracing-cpp to support cmake 4.x

* downgrade cmake to 3.31.0 for the macos conan stable version test

* don't use sudo to run the setup cmake script on macos

Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed