### PR TITLE
[CODE HEALTH] Fix misc clang-tidy warnings (#3993)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ Increment the:
 * [CODE HEALTH] Fix clang-tidy narrowing conversions in baggage
   [#3989](https://github.com/open-telemetry/opentelemetry-cpp/pull/3989)
 
+* [CODE HEALTH] Fix misc clang-tidy warnings
+  [#3993](https://github.com/open-telemetry/opentelemetry-cpp/pull/3993)
+
 Important changes:
 
 * Enable WITH_OTLP_RETRY_PREVIEW by default

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -294,6 +294,8 @@ private:
     return SetCurlPtrOption(option, list);
   }
 
+  // Curl parameter must really be a long
+  // NOLINTNEXTLINE(google-runtime-int)
   CURLcode SetCurlLongOption(CURLoption option, long value);
 
   CURLcode SetCurlOffOption(CURLoption option, curl_off_t value);
@@ -334,6 +336,8 @@ private:
   std::chrono::system_clock::time_point last_attempt_time_;
 
   // Processed response headers and body
+  // See CURLINFO_RESPONSE_CODE, type is long
+  // NOLINTNEXTLINE(google-runtime-int)
   long response_code_{0};
   std::vector<uint8_t> response_headers_;
   std::vector<uint8_t> response_body_;

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -52,10 +52,6 @@
 
 #endif
 
-#ifndef _Out_cap_
-#  define _Out_cap_(size)
-#endif
-
 #if defined(HAVE_CONSOLE_LOG) && !defined(LOG_DEBUG)
 // Log to console if there's no standard log facility defined
 #  include <cstdio>
@@ -336,7 +332,7 @@ struct Socket
     m_sock = Invalid;
   }
 
-  int recv(_Out_cap_(size) void *buffer, unsigned size)
+  int recv(void *buffer, unsigned size)
   {
     assert(m_sock != Invalid);
     int flags = 0;


### PR DESCRIPTION
Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed