### PR TITLE
[CODE HEALTH] Fix clang-tidy misc-no-recursion warnings (#4009)

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 35
+            warning_limit: 31
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 37
+            warning_limit: 33
     env:
       CC: /usr/bin/clang-18
       CXX: /usr/bin/clang++-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ Increment the:
 * Enable ENABLE_OTLP_RETRY_PREVIEW for bazel
   [#4010](https://github.com/open-telemetry/opentelemetry-cpp/pull/4010)
 
+* [CODE HEALTH] Fix clang-tidy misc-no-recursion warnings
+  [#4009](https://github.com/open-telemetry/opentelemetry-cpp/pull/4009)
+
 Important changes:
 
 * Enable WITH_OTLP_RETRY_PREVIEW by default

--- a/sdk/src/metrics/data/circular_buffer.cc
+++ b/sdk/src/metrics/data/circular_buffer.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <stddef.h>
+#include <cassert>
 #include <cstdint>
 #include <limits>
 #include <utility>
@@ -83,13 +84,17 @@ struct AdaptingIntegerArrayCopy
 
 void AdaptingIntegerArray::Increment(size_t index, uint64_t count)
 {
+  /* May or may not fit */
   const uint64_t result = nostd::visit(AdaptingIntegerArrayIncrement{index, count}, backing_);
   if OPENTELEMETRY_LIKELY_CONDITION (result == 0)
   {
     return;
   }
   EnlargeToFit(result);
-  Increment(index, count);
+  /* Must fit, buffer was enlarged for the value to store */
+  OPENTELEMETRY_MAYBE_UNUSED const uint64_t result2 =
+      nostd::visit(AdaptingIntegerArrayIncrement{index, count}, backing_);
+  assert(result2 == 0);
 }
 
 uint64_t AdaptingIntegerArray::Get(size_t index) const


### PR DESCRIPTION
Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed