### PR TITLE
[SDK] env var durations non conforming to spec (#4020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ Increment the:
 * [API] Deprecate opentelemetry::plugin
   [#4021](https://github.com/open-telemetry/opentelemetry-cpp/pull/4021)
 
+* [SDK] env var durations non conforming to spec
+  [#4020](https://github.com/open-telemetry/opentelemetry-cpp/pull/4020)
+
 Important changes:
 
 * Enable WITH_OTLP_RETRY_PREVIEW by default
@@ -114,6 +117,37 @@ Important changes:
 
   * namespace opentelemetry::plugin is deprecated
   * See file DEPRECATED.md for details.
+
+Breaking changes:
+
+* [SDK] env var durations non conforming to spec
+  [#4020](https://github.com/open-telemetry/opentelemetry-cpp/pull/4020)
+
+  * Environment variables for durations can accept two formats, with units
+    (`15s`, `15000ms`) or without units (`15000`).
+  * When parsing environment variables that represent durations,
+    and only in the case no unit is provided,
+    for example `OTEL_METRIC_EXPORT_INTERVAL=15000`,
+    the code interpreted the value, `15000`,
+    in seconds instead of milliseconds per the specifications.
+  * Parsing duration without units has been fixed to use milliseconds.
+  * As a consequence, every duration environment variable set
+    without a unit is now interpreted differently, which is a breaking change.
+  * For example, `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT=30` meant 30 seconds
+    before, and now means 30 milliseconds.
+    To preserve the same behavior, existing values must be adjusted,
+    to either `30000` or `30000ms` or `30s` in this case.
+  * The following variables are affected:
+    * OTEL_EXPORTER_OTLP_TRACES_TIMEOUT
+    * OTEL_EXPORTER_OTLP_METRICS_TIMEOUT
+    * OTEL_EXPORTER_OTLP_LOGS_TIMEOUT
+    * OTEL_EXPORTER_OTLP_TIMEOUT
+    * OTEL_BLRP_SCHEDULE_DELAY
+    * OTEL_BLRP_EXPORT_TIMEOUT
+    * OTEL_METRIC_EXPORT_INTERVAL
+    * OTEL_METRIC_EXPORT_TIMEOUT
+    * OTEL_BSP_SCHEDULE_DELAY
+    * OTEL_BSP_EXPORT_TIMEOUT
 
 ## [1.26.0] 2026-03-19
 

--- a/sdk/src/common/env_variables.cc
+++ b/sdk/src/common/env_variables.cc
@@ -159,11 +159,11 @@ static bool GetTimeoutFromString(const char *input, std::chrono::system_clock::d
 
   if (unit == "")
   {
-    // TODO: The spec says milliseconds, but opentelemetry-cpp implemented
-    // seconds by default. Fixing this is a breaking change.
+    // The spec says milliseconds, but opentelemetry-cpp implemented
+    // seconds by default, up to opentelemetry-cpp 1.26.0.
 
     value = std::chrono::duration_cast<std::chrono::system_clock::duration>(
-        std::chrono::seconds{result});
+        std::chrono::milliseconds{result});
     return true;
   }
 

--- a/sdk/test/common/env_var_test.cc
+++ b/sdk/test/common/env_var_test.cc
@@ -187,9 +187,11 @@ TEST(EnvVarTest, DurationEnvVar)
   EXPECT_EQ(value, expected);
 
   value = poison;
+  // Up to opentelemetry-cpp 1.26.0:
   // Deviation from the spec: 123 seconds instead of 123 milliseconds
-  expected =
-      std::chrono::duration_cast<std::chrono::system_clock::duration>(std::chrono::seconds{123});
+  // Now fixed, 123 milliseconds
+  expected = std::chrono::duration_cast<std::chrono::system_clock::duration>(
+      std::chrono::milliseconds{123});
   exists = GetDurationEnvironmentVariable("DURATION_ENV_VAR_7", value);
   EXPECT_TRUE(exists);
   EXPECT_EQ(value, expected);


### PR DESCRIPTION
Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed