### PR TITLE
[SDK] MeterProvider: do not warn in destructor after explicit Shutdow…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Increment the:
 * [CODE HEALTH] Remove unused alias declarations
   [#4091](https://github.com/open-telemetry/opentelemetry-cpp/pull/4091)
 
+* [SDK] MeterProvider: do not warn in destructor after explicit Shutdown
+  [#4085](https://github.com/open-telemetry/opentelemetry-cpp/pull/4085)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <mutex>
@@ -143,6 +144,13 @@ public:
 private:
   std::shared_ptr<MeterContext> context_;
   std::mutex lock_;
+
+#if defined(__cpp_lib_atomic_value_initialization) && \
+    __cpp_lib_atomic_value_initialization >= 201911L
+  std::atomic_flag shutdown_latch_{};
+#else
+  std::atomic_flag shutdown_latch_ = ATOMIC_FLAG_INIT;
+#endif
 };
 }  // namespace metrics
 }  // namespace sdk

--- a/sdk/src/metrics/meter_provider.cc
+++ b/sdk/src/metrics/meter_provider.cc
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <atomic>
 #include <chrono>
 #include <mutex>
 #include <utility>
@@ -143,6 +144,11 @@ void MeterProvider::SetExemplarFilter(metrics::ExemplarFilterType exemplar_filte
  */
 bool MeterProvider::Shutdown(std::chrono::microseconds timeout) noexcept
 {
+  // Shutdown only once
+  if (shutdown_latch_.test_and_set(std::memory_order_acquire))
+  {
+    return true;
+  }
   return context_->Shutdown(timeout);
 }
 
@@ -162,7 +168,7 @@ MeterProvider::~MeterProvider()
 {
   if (context_)
   {
-    context_->Shutdown();
+    Shutdown();
   }
 }
 

--- a/sdk/test/metrics/meter_provider_sdk_test.cc
+++ b/sdk/test/metrics/meter_provider_sdk_test.cc
@@ -2,14 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <mutex>
 #include <string>
 #include <utility>
+#include <vector>
 #include "common.h"
 
 #include "opentelemetry/common/macros.h"
 #include "opentelemetry/metrics/meter.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/metrics/meter.h"
 #include "opentelemetry/sdk/metrics/meter_provider.h"
@@ -33,6 +36,78 @@
 #endif /* OPENTELEMETRY_ABI_VERSION_NO >= 2 */
 
 using namespace opentelemetry::sdk::metrics;
+using namespace opentelemetry::sdk::common::internal_log;
+
+namespace
+{
+
+class ScopedTestLogHandler final
+{
+public:
+  struct Entry
+  {
+    LogLevel level;
+    std::string msg;
+  };
+
+private:
+  class LogHandlerImpl : public LogHandler
+  {
+  public:
+    void Handle(LogLevel level,
+                const char * /*file*/,
+                int /*line*/,
+                const char *msg,
+                const opentelemetry::sdk::common::AttributeMap & /*attrs*/) noexcept override
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      entries_.push_back({level, msg ? msg : ""});
+    }
+
+    std::vector<Entry> Drain()
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      return std::exchange(entries_, {});
+    }
+
+  private:
+    std::mutex mu_;
+    std::vector<Entry> entries_;
+  };
+
+public:
+  explicit ScopedTestLogHandler(LogLevel level)
+      : previous_handler_(GlobalLogHandler::GetLogHandler()),
+        previous_level_(GlobalLogHandler::GetLogLevel())
+  {
+    opentelemetry::nostd::shared_ptr<LogHandlerImpl> handler{new LogHandlerImpl{}};
+    handler_ = handler.get();
+
+    GlobalLogHandler::SetLogHandler(std::move(handler));
+    GlobalLogHandler::SetLogLevel(level);
+  }
+
+  ~ScopedTestLogHandler()
+  {
+    handler_ = nullptr;
+    GlobalLogHandler::SetLogHandler(previous_handler_);
+    GlobalLogHandler::SetLogLevel(previous_level_);
+  }
+
+  ScopedTestLogHandler(const ScopedTestLogHandler &)            = delete;
+  ScopedTestLogHandler &operator=(const ScopedTestLogHandler &) = delete;
+  ScopedTestLogHandler(ScopedTestLogHandler &&)                 = delete;
+  ScopedTestLogHandler &operator=(ScopedTestLogHandler &&)      = delete;
+
+  std::vector<Entry> Drain() { return handler_->Drain(); }
+
+private:
+  LogHandlerImpl *handler_{nullptr};
+  opentelemetry::nostd::shared_ptr<LogHandler> previous_handler_;
+  LogLevel previous_level_;
+};
+
+}  // namespace
 
 TEST(MeterProvider, GetMeter)
 {
@@ -322,3 +397,19 @@ TEST(MeterProvider, GetMeterInequalityCheckAbiv2)
 }
 
 #endif /* OPENTELEMETRY_ABI_VERSION_NO >= 2 */
+
+TEST(MeterProvider, ExplicitShutdownNotWarnOnDestructionCheck)
+{
+  ScopedTestLogHandler log_handler{LogLevel::Warning};
+
+  auto provider = MeterProviderFactory::Create();
+  // Explicit shutdown
+  provider->Shutdown();
+  auto logs = log_handler.Drain();
+  EXPECT_TRUE(logs.empty());
+
+  // Implicit shutdown via destructor
+  provider = nullptr;
+  logs     = log_handler.Drain();
+  EXPECT_TRUE(logs.empty());
+}


### PR DESCRIPTION
…n (#4085)

Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed